### PR TITLE
DPE-108  Add PR template 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Issue
+<!-- What does this PR solve? Include a Jira ticket.  -->
+
+## Solution
+<!-- A summary of the proposed solution to the above issue. -->
+
+## Context
+<!-- Necessary details to understand the proposed changes. -->
+
+## Release Notes
+<!-- A simple bullet-point summary of the changes in this PR. -->
+
+## Testing
+<!-- A summary of how this PR has been tested, including automated testing. -->


### PR DESCRIPTION
## Description
PR templates have proved useful in other operator repos, so one should be added to this repo. 

## Context
- This is a flexible guideline, and not a rigidly defined document. It should remain mutable by PR authors to minimise time spent reading and writing unnecessary filler. 