### PR TITLE
Removed unnecessary user management

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-    pull_request:
+  pull_request:
 
 jobs:
   lint:

--- a/actions.yaml
+++ b/actions.yaml
@@ -3,36 +3,3 @@
 
 reload-pgbouncer:
   description: Reloads pgbouncer application. This does not restart the container.
-
-add-user:
-  description: Adds a new pgbouncer user.
-  params:
-    username:
-      type: string
-      description: The username of the given user. If a user exists by this name, this action will fail.
-    password:
-      type: string
-      description: The password of the given user
-  required: [username, password]
-
-remove-user:
-  description: Removes pgbouncer user. NB this can only remove users added through the `add-user` action; users added using the charm config must be removed from the config, and through this action.
-  params:
-    username:
-      type: string
-      description: The username of the given user. If a user by this name does not exist, this action will fail.
-  required: [username]
-
-change-password:
-  description: Changes password for a given user.
-  params:
-    username:
-      type: string
-      description: Username of an existing user
-    password:
-      type: string
-      description: The new password
-  required: [username, password]
-
-get-users:
-  description: Lists all pgbouncer users.

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,8 +18,9 @@ from ops.pebble import Layer
 
 logger = logging.getLogger(__name__)
 
-INI_PATH = "/etc/pgbouncer/pgbouncer.ini"
-USERLIST_PATH = "/etc/pgbouncer/userlist.txt"
+PGB_DIR = "/etc/pgbouncer"
+INI_PATH = f"{PGB_DIR}/pgbouncer.ini"
+USERLIST_PATH = f"{PGB_DIR}/userlist.txt"
 
 
 class PgBouncerK8sCharm(CharmBase):
@@ -38,10 +39,6 @@ class PgBouncerK8sCharm(CharmBase):
         self.framework.observe(self.on.pgbouncer_pebble_ready, self._on_pgbouncer_pebble_ready)
 
         self.framework.observe(self.on.reload_pgbouncer_action, self._on_reload_pgbouncer_action)
-        self.framework.observe(self.on.change_password_action, self._on_change_password_action)
-        self.framework.observe(self.on.add_user_action, self._on_add_user_action)
-        self.framework.observe(self.on.remove_user_action, self._on_remove_user_action)
-        self.framework.observe(self.on.get_users_action, self._on_get_users_action)
 
     # =======================
     #  Charm Lifecycle Hooks
@@ -124,82 +121,6 @@ class PgBouncerK8sCharm(CharmBase):
         """
         self._reload_pgbouncer()
         event.set_results({"result": "pgbouncer application has restarted"})
-
-    def _on_change_password_action(self, event: ActionEvent) -> None:
-        """An action to update the password for a specific user.
-
-        Currently passwords are hashed using md5.
-
-        Args:
-            event: ActionEvent containing a "username" parameter, defining the user whose password
-                will be modified, and a "password" parameter, defining the new password.
-        """
-        username = event.params["username"]
-        # Get users from pgbouncer container and check that the given username doesn't exist.
-        users = self._get_userlist_from_container()
-        if username not in users.keys():
-            event.set_results(
-                {
-                    "result": f"user {username} does not exist - use the get-users action to list existing users."
-                }
-            )
-            return
-
-        users[username] = self._hash(event.params["password"])
-        self._push_container_config(users=users)
-        event.set_results({"result": f"password updated for user {username}"})
-
-    def _on_add_user_action(self, event: ActionEvent) -> None:
-        """Event handler for add-user action.
-
-        Currently passwords are hashed using md5.
-
-        Args:
-            event: ActionEvent containing a "username" parameter, defining the user to be added,
-                and a "password" parameter, defining the user's password.
-        """
-        username = event.params["username"]
-        # Get users from pgbouncer container and check that the given username doesn't exist.
-        users = self._get_userlist_from_container()
-        if username in users.keys():
-            event.set_results({"result": f"user {username} already exists"})
-            return
-
-        users[username] = self._hash(event.params["password"])
-        self._push_container_config(users)
-        event.set_results({"result": f"new user {username} added"})
-
-    def _on_remove_user_action(self, event: ActionEvent) -> None:
-        """Event handler for remove-user action.
-
-        As of now, this only removes the user from userlist.txt, and not the juju config.
-        Therefore, users defined in the juju config are reinstated with a generated password next
-        time userlist.txt is generated from local config, causing the user to persist. It remains
-        inaccessible due to the new password. To remove this user, it must also be removed from
-        the config.
-
-        Args:
-            event: ActionEvent containing a "username" parameter, defining the user to be removed.
-        """
-        username = event.params["username"]
-        # Get users from pgbouncer container and check that the given username doesn't exist.
-        users = self._get_userlist_from_container()
-        if username not in users:
-            event.set_results({"result": f"user {username} does not exist"})
-            return
-
-        # Remove user from local userlist variable and render updated userlist.txt to container
-        del users[username]
-        self._push_container_config(users=users)
-        event.set_results({"result": f"user {username} removed"})
-
-    def _on_get_users_action(self, event: ActionEvent) -> None:
-        """Event handler for get-users action.
-
-        Prints a space-separated list of existing usernames from pgbouncer.ini
-        """
-        users = self._get_userlist_from_container()
-        event.set_results({"result": " ".join(users.keys())})
 
     # ===================================
     #  User management support functions

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -2,7 +2,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import hashlib
 import logging
 from pathlib import Path
 
@@ -15,8 +14,9 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
-INI_PATH = "/etc/pgbouncer/pgbouncer.ini"
-USERLIST_PATH = "/etc/pgbouncer/userlist.txt"
+PGB_DIR = "/etc/pgbouncer"
+INI_PATH = f"{PGB_DIR}/pgbouncer.ini"
+USERLIST_PATH = f"{PGB_DIR}/userlist.txt"
 
 
 @pytest.mark.abort_on_fail
@@ -33,81 +33,3 @@ async def test_build_and_deploy(ops_test: OpsTest):
         config={"pgb_admin_users": "juju-admin"},
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
-
-
-async def test_user_management(ops_test: OpsTest):
-    """Test user management through config and actions.
-
-    We complete the following steps, verifying each action has the expected output:
-    - Create a user through `pgb_admin_users` config variable
-    - Change this user's password
-    - Add a new user through the `add-user` action
-    - Check we have all three expected users, using the `get-users` action
-    - Remove the created users in preparation for the next test, and check that they have been
-      removed using the `get-users` action
-    """
-    await ops_test.model.applications[APP_NAME].set_config({"pgb_admin_users": "test1"})
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
-
-    # check test1 and juju-admin users have generated and hashed passwords
-    userlist = await get_userlist_from_container(ops_test)
-    assert "juju-admin" in userlist
-    assert "test1" in userlist
-
-    unit = ops_test.model.applications[APP_NAME].units[0]
-    action = await unit.run_action("change-password", username="test1", password="pw1")
-    action = await action.wait()
-    assert action.results["result"] == "password updated for user test1"
-
-    action = await unit.run_action("add-user", username="test2", password="pw2")
-    action = await action.wait()
-    assert action.results["result"] == "new user test2 added"
-
-    action = await unit.run_action("get-users")
-    action = await action.wait()
-    # juju-admin is the default user defined in config.yaml
-    assert action.results["result"] == "juju-admin test1 test2"
-
-    # Assert passwords are correct, with expected md5 hashing. This also verifies userlist.txt is
-    # correctly formatted, with double quotes surrounding usernames and hashed passwords.
-    userlist = await get_userlist_from_container(ops_test)
-    assert "juju-admin" in userlist
-    assert f'"test1" "{hashlib.md5("pw1".encode()).hexdigest()}"' in userlist
-    assert f'"test2" "{hashlib.md5("pw2".encode()).hexdigest()}"' in userlist
-
-    # teardown users before next test
-    action = await unit.run_action("remove-user", username="test1")
-    action = await action.wait()
-    assert action.results["result"] == "user test1 removed"
-
-    action = await unit.run_action("remove-user", username="test2")
-    action = await action.wait()
-    assert action.results["result"] == "user test2 removed"
-
-    action = await unit.run_action("get-users")
-    action = await action.wait()
-    assert action.results["result"] == "juju-admin"
-
-    # Assert juju-admin in userlist, and test1 and test2 have been removed.
-    userlist = await get_userlist_from_container(ops_test)
-    assert "juju-admin" in userlist
-    assert "test1" not in userlist
-    assert "test2" not in userlist
-
-
-async def get_userlist_from_container(ops_test):
-    """Helper function to get userlist.txt from pgbouncer container.
-
-    ops_test.scp_from() doesn't seem to work on k8s charms, and we don't particularly want to save
-    the file locally anyway, so instead we run `cat` over ssh and return the output.
-    """
-    userlist = await ops_test.run(
-        "juju",
-        "ssh",
-        "--container",
-        "pgbouncer",
-        f"{APP_NAME}/0",
-        "cat",
-        f"{USERLIST_PATH}",
-    )
-    return userlist[1]


### PR DESCRIPTION
## Proposal
The user management previously implemented in this charm is unnecessary, and has been removed. This PR is separate from the rest of the k8s charm update work to make it easier to review. 

## Context
This code was written when I had a worse understanding of the intended purpose of this charm. Postgres/pgbouncer users shouldn't be managed directly by the pgbouncer charm user; instead, they should be derived from the postgres charm relation. Therefore, this code is unnecessary. 

The failing integration tests are due to the docker image not being available on github; a future PR will fix this. 

## Release Notes
- Removed the following user management actions, as well as their associated tests:
  - change_password
  - add_user
  - remove_user
  - get_users

## Testing
- Removed irrelevant unit & integration tests. Remaining unit & integration tests still pass. 
- Manually tested build & deploy stage
