### PR TITLE
image override to pin uploaded revision

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,6 +74,8 @@ jobs:
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.0.0-rc
         with:
+          resource-overrides: "pgbouncer-image:2"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
+


### PR DESCRIPTION
## Proposal

Have auto release use a pinned revision of pgbouncer oci image.

## Context

Because we don't have pgbouncer rock in place yet (e.g. image published to official canonical channels).
