### PR TITLE
fixed release CI to use correct juju version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,8 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed.
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration tests
         run: tox -e integration
 


### PR DESCRIPTION
## Proposal
Release.yaml doesn't use the correct juju version to get around the scale-down bug. This PR fixes that. 
