### PR TITLE
Fix endpoints to point to correct units when scaling

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -8,6 +8,7 @@
 import logging
 import os
 import socket
+from typing import Optional
 
 from charms.pgbouncer_k8s.v0 import pgb
 from charms.pgbouncer_k8s.v0.pgb import PgbConfig
@@ -88,7 +89,7 @@ class PgBouncerK8sCharm(CharmBase):
         if config["pgbouncer"]["listen_port"] != self.config["listen_port"]:
             # This emits relation-changed events to every client relation, so only do it when
             # necessary
-            self.update_backend_relation_port(self.config["listen_port"])
+            self.update_client_connection_info(self.config["listen_port"])
             config["pgbouncer"]["listen_port"] = self.config["listen_port"]
 
         self.render_pgb_config(config)
@@ -310,17 +311,17 @@ class PgBouncerK8sCharm(CharmBase):
     #  Relation Utilities
     # =====================
 
-    def update_backend_relation_port(self, port):
-        """Update ports in backend relations to match updated pgbouncer port."""
+    def update_client_connection_info(self, port: Optional[str] = None):
+        """Update connection info in client relations."""
         # Skip updates if backend.postgres doesn't exist yet.
         if not self.backend.postgres:
             return
 
         for relation in self.model.relations.get("db", []):
-            self.legacy_db_relation.update_port(relation, port)
+            self.legacy_db_relation.update_connection_info(relation, port)
 
         for relation in self.model.relations.get("db-admin", []):
-            self.legacy_db_admin_relation.update_port(relation, port)
+            self.legacy_db_admin_relation.update_connection_info(relation, port)
 
     def update_postgres_endpoints(self, reload_pgbouncer=False):
         """Update postgres endpoints in relation config values."""

--- a/src/relations/backend_database.py
+++ b/src/relations/backend_database.py
@@ -146,6 +146,7 @@ class BackendDatabaseRequires(Object):
             self.charm.unit.status = BlockedStatus(
                 "failed to remove auth user when disconnecting from postgres application."
             )
+            event.fail()
             return
 
         self.postgres.delete_user(self.auth_user)

--- a/src/relations/backend_database.py
+++ b/src/relations/backend_database.py
@@ -143,10 +143,9 @@ class BackendDatabaseRequires(Object):
                 cursor.execute(uninstall_script.replace("auth_user", self.auth_user))
             conn.close()
         except psycopg2.Error:
-            self.charm.unit.status = BlockedStatus(
-                "failed to remove auth user when disconnecting from postgres application."
-            )
-            event.fail()
+            auth_fail = "failed to remove auth user when disconnecting from postgres application."
+            self.charm.unit.status = BlockedStatus(auth_fail)
+            event.fail(auth_fail)
             return
 
         self.postgres.delete_user(self.auth_user)

--- a/src/relations/db.py
+++ b/src/relations/db.py
@@ -289,22 +289,27 @@ class DbProvides(Object):
             logger.warning("relation not fully initialised - skipping port update")
             return
 
-        dbconnstr = pgb.parse_dict_to_kv_string(
-            {
-                "host": self.charm.unit_pod_hostname,
-                "dbname": database,
-                "port": port,
-                "user": user,
-                "password": password,
-                "fallback_application_name": self.get_external_app(relation).name,
-            }
-        )
+        master_dbconnstr = {
+            "host": self.charm.peers.leader_hostname,
+            "dbname": database,
+            "port": port,
+            "user": user,
+            "password": password,
+            "fallback_application_name": self.get_external_app(relation).name,
+        }
+
+        standby_dbconnstrs = []
+        for standby_ip in self.charm.peers.units_hostnames - {self.charm.peers.leader_hostname}:
+            standby_dbconnstr = dict(master_dbconnstr)
+            standby_dbconnstr.update({"host": standby_ip})
+            standby_dbconnstrs.append(pgb.parse_dict_to_kv_string(standby_dbconnstr))
+
         self.update_databags(
             relation,
             {
-                "master": dbconnstr,
+                "master": pgb.parse_dict_to_kv_string(master_dbconnstr),
                 "port": str(port),
-                "standbys": dbconnstr,
+                "standbys": ",".join(standby_dbconnstrs),
             },
         )
 

--- a/src/relations/peers.py
+++ b/src/relations/peers.py
@@ -143,6 +143,7 @@ class Peers(Object):
             return None
 
     def _on_created(self, event: RelationCreatedEvent):
+        self.unit_databag[ADDRESS_KEY] = self.charm.unit_pod_hostname
         if not self.charm.unit.is_leader():
             return
 
@@ -189,6 +190,9 @@ class Peers(Object):
                 # raises an error if this is fired before on_pebble_ready.
                 self.charm.reload_pgbouncer()
             except ConnectionError:
+                logger.error(
+                    "failed to reload pgbouncer - deferring change_event and waiting for pebble."
+                )
                 event.defer()
 
     def _on_departed(self, _):

--- a/src/relations/peers.py
+++ b/src/relations/peers.py
@@ -52,17 +52,19 @@ Example:
 """  # noqa: W505
 
 import logging
-from typing import Optional
+from typing import Optional, Set
 
 from charms.pgbouncer_k8s.v0.pgb import PgbConfig
 from ops.charm import CharmBase, RelationChangedEvent, RelationCreatedEvent
 from ops.framework import Object
+from ops.model import Unit
 from ops.pebble import ConnectionError
 
 from constants import PEER_RELATION_NAME
 
 CFG_FILE_DATABAG_KEY = "cfg_file"
 AUTH_FILE_DATABAG_KEY = "auth_file"
+ADDRESS_KEY = "private-address"
 
 
 logger = logging.getLogger(__name__)
@@ -89,16 +91,52 @@ class Peers(Object):
         self.framework.observe(charm.on[PEER_RELATION_NAME].relation_changed, self._on_changed)
 
     @property
+    def relation(self):
+        """Returns the relations in this model , or None if peer is not initialised."""
+        return self.model.get_relation(PEER_RELATION_NAME, None)
+
+    @property
     def app_databag(self):
         """Returns the app databag for the Peer relation."""
-        peer_relation = self.model.get_relation(PEER_RELATION_NAME)
-        return peer_relation.data[self.charm.app]
+        if not self.relation:
+            return None
+        return self.relation.data[self.charm.app]
 
     @property
     def unit_databag(self):
         """Returns the unit databag for the Peer relation."""
-        peer_relation = self.model.get_relation(PEER_RELATION_NAME)
-        return peer_relation.data[self.charm.unit]
+        if not self.relation:
+            return None
+        return self.relation.data[self.charm.unit]
+
+    @property
+    def units_hostnames(self) -> Set[str]:
+        """Fetch current list of peers hostnames.
+
+        Returns:
+            A list of peers addresses (strings).
+        """
+        # Get all members IPs and remove the current unit IP from the list.
+        addresses = {self._get_unit_hostname(unit) for unit in self.relation.units}
+        addresses.add(self.charm.unit_pod_hostname)
+        return addresses
+
+    @property
+    def leader_hostname(self) -> str:
+        """Gets the hostname of the leader unit."""
+        return self.app_databag.get("leader", None)
+
+    def _get_unit_hostname(self, unit: Unit) -> Optional[str]:
+        """Get the hostname of a specific unit."""
+        # Check if host is current host.
+        if unit == self.charm.unit:
+            return self.charm.unit_pod_hostname
+        # Check if host is a peer.
+        elif unit in self.relation.data:
+            return str(self.relation.data[unit].get(ADDRESS_KEY))
+        # Return None if the unit is not a peer neither the current unit.
+        else:
+            return None
 
     def _on_created(self, event: RelationCreatedEvent):
         if not self.charm.unit.is_leader():
@@ -121,6 +159,8 @@ class Peers(Object):
 
     def _on_changed(self, event: RelationChangedEvent):
         """If the current unit is a follower, write updated config and auth files to filesystem."""
+        self.unit_databag[ADDRESS_KEY] = self.charm.unit_pod_hostname
+
         if self.charm.unit.is_leader():
             try:
                 cfg = self.charm.read_pgb_config()
@@ -131,6 +171,7 @@ class Peers(Object):
                 return
 
             self.update_cfg(cfg)
+            self.app_databag["leader"] = self.charm.unit_pod_hostname
             return
 
         if cfg := self.get_secret("app", CFG_FILE_DATABAG_KEY):
@@ -141,10 +182,9 @@ class Peers(Object):
 
         if cfg is not None or auth_file is not None:
             try:
-                # returns an error if this is fired before on_pebble_ready.
+                # raises an error if this is fired before on_pebble_ready.
                 self.charm.reload_pgbouncer()
             except ConnectionError:
-                # TODO find a better error to use
                 event.defer()
 
     def set_secret(self, scope: str, key: str, value: str):

--- a/tests/unit/relations/test_backend_database.py
+++ b/tests/unit/relations/test_backend_database.py
@@ -13,8 +13,7 @@ from charms.pgbouncer_k8s.v0.pgb import (
 from ops.testing import Harness
 
 from charm import PgBouncerK8sCharm
-
-BACKEND_RELATION_NAME = "backend-database"
+from constants import BACKEND_RELATION_NAME, PEER_RELATION_NAME
 
 # TODO clean up mocks
 
@@ -99,6 +98,7 @@ class TestBackendDatabaseRelation(unittest.TestCase):
     )
     @patch("charm.PgBouncerK8sCharm.update_postgres_endpoints")
     def test_relation_departed(self, _update_endpoints, _postgres, _auth_user):
+        self.harness.add_relation(PEER_RELATION_NAME, "postgres")
         self.harness.set_leader(True)
         postgres = _postgres.return_value
         depart_event = MagicMock()

--- a/tests/unit/relations/test_db.py
+++ b/tests/unit/relations/test_db.py
@@ -12,6 +12,7 @@ from constants import (
     DB_ADMIN_RELATION_NAME,
     DB_RELATION_NAME,
     PEER_RELATION_NAME,
+
 )
 from lib.charms.pgbouncer_k8s.v0.pgb import (
     DEFAULT_CONFIG,
@@ -125,104 +126,127 @@ class TestDb(unittest.TestCase):
         _create_user.assert_called_with(user, password, admin=False)
 
     @patch(
-        "relations.backend_database.BackendDatabaseRequires.postgres_databag",
-        new_callable=PropertyMock,
-    )
-    @patch(
         "relations.backend_database.BackendDatabaseRequires.postgres", new_callable=PropertyMock
     )
-    @patch("charm.PgBouncerK8sCharm.read_pgb_config", return_value=PgbConfig(DEFAULT_CONFIG))
-    @patch(
-        "charm.PgBouncerK8sCharm.unit_pod_hostname",
-        new_callable=PropertyMock,
-        return_value="test-host",
-    )
-    @patch("relations.db.DbProvides.get_external_app")
-    @patch("relations.db.DbProvides.get_allowed_units", return_value="test_allowed_unit")
-    @patch("relations.db.DbProvides.get_allowed_subnets", return_value="test_allowed_subnet")
-    @patch("relations.db.DbProvides._get_state", return_value="test-state")
-    @patch("charm.PgBouncerK8sCharm.render_pgb_config")
-    @patch("charms.postgresql_k8s.v0.postgresql.PostgreSQL")
+    @patch("relations.db.DbProvides.get_databags", return_value=[{}])
+    @patch("relations.db.DbProvides.update_port")
+    @patch("relations.db.DbProvides.update_postgres_endpoints")
+    @patch("relations.db.DbProvides.update_databags")
+    @patch("relations.db.DbProvides.get_allowed_units")
+    @patch("relations.db.DbProvides.get_allowed_subnets")
+    @patch("relations.db.DbProvides._get_state")
     def test_on_relation_changed(
         self,
-        _postgres,
-        _render_cfg,
-        _state,
+        _get_state,
         _allowed_subnets,
         _allowed_units,
-        _external_app,
-        _hostname,
-        _read_cfg,
+        _update_databags,
+        _update_postgres_endpoints,
+        _update_port,
+        _get_databags,
         _backend_postgres,
-        _postgres_databag,
     ):
-        # Ensure event doesn't defer too early
         self.harness.set_leader(True)
 
-        # set up mocks
-        _read_cfg.return_value["databases"]["test_db"] = {
-            "host": "test-host",
-            "dbname": "external_test_unit",
-            "port": "test_port",
-            "user": "test_user",
-            "password": "test_pass",
-            "fallback_application_name": "external_test_unit",
-        }
-
-        mock_event = MagicMock()
-        relation_data = mock_event.relation.data = {}
         database = "test_db"
         user = "test_user"
         password = "test_pw"
+        _get_databags.return_value[0] = {
+            "database": database,
+            "user": user,
+            "password": password,
+        }
 
-        pgb_app_databag = relation_data[self.charm.app] = {}
-        pgb_unit_databag = relation_data[self.charm.unit] = {}
-        self.db_relation.update_databags(
-            mock_event.relation,
+        # Call the function
+        event = MagicMock()
+        self.db_relation._on_relation_changed(event)
+
+        _update_port.assert_called_with(event.relation, self.charm.config["listen_port"])
+        _update_postgres_endpoints.assert_called_with(event.relation, reload_pgbouncer=True)
+        _update_databags.assert_called_with(
+            event.relation,
             {
-                "database": database,
+                "allowed-subnets": _allowed_subnets.return_value,
+                "allowed-units": _allowed_units.return_value,
+                "version": self.charm.backend.postgres.get_postgresql_version(),
+                "host": self.charm.unit_pod_hostname,
                 "user": user,
                 "password": password,
+                "database": database,
+                "state": _get_state.return_value,
             },
         )
 
-        external_app = _external_app.return_value
-        relation_data[external_app] = {}
-        external_app.name = "external_test_app"
+    @patch("relations.db.DbProvides.get_databags", return_value=[{}])
+    @patch("relations.db.DbProvides.get_external_app")
+    @patch("relations.db.DbProvides.update_databags")
+    def test_update_port(self, _update_databags, _get_external_app, _get_databags):
+        relation = MagicMock()
+        database = "test_db"
+        user = "test_user"
+        password = "test_pw"
+        port = "5555"
 
-        _backend_postgres.return_value = _postgres
-        _postgres.get_postgresql_version.return_value = "12"
+        _get_databags.return_value[0] = {
+            "database": database,
+            "user": user,
+            "password": password,
+        }
 
-        # Call the function
-        self.db_relation._on_relation_changed(mock_event)
+        master_dbconnstr = {
+            "host": self.charm.peers.leader_hostname,
+            "dbname": database,
+            "port": port,
+            "user": user,
+            "password": password,
+            "fallback_application_name": _get_external_app().name,
+        }
 
-        # evaluate output
-        dbconnstr = parse_dict_to_kv_string(
+        standby_dbconnstrs = []
+        for standby_hostname in self.charm.peers.units_hostnames - {self.charm.peers.leader_hostname}:
+            standby_dbconnstr = dict(master_dbconnstr)
+            standby_dbconnstr.update({"host": standby_hostname})
+            standby_dbconnstrs.append(parse_dict_to_kv_string(standby_dbconnstr))
+
+        self.db_relation.update_port(relation, port)
+        _update_databags.assert_called_with(
+            relation,
             {
-                "host": self.charm.unit_pod_hostname,
-                "dbname": database,
-                "port": self.charm.config["listen_port"],
-                "user": user,
-                "password": password,
-                "fallback_application_name": external_app.name,
-            }
+                "master": parse_dict_to_kv_string(master_dbconnstr),
+                "port": port,
+                "standbys": ",".join(standby_dbconnstrs),
+            },
         )
 
-        for databag in [pgb_app_databag, pgb_unit_databag]:
-            assert databag["allowed-subnets"] == _allowed_subnets.return_value
-            assert databag["allowed-units"] == _allowed_units.return_value
-            assert databag["host"] == _hostname.return_value
-            assert databag["master"] == dbconnstr
-            assert databag["port"] == str(self.charm.config["listen_port"])
-            assert databag["standbys"] == dbconnstr
-            assert databag["version"] == "12"
-            assert databag["user"] == user
-            assert databag["password"] == password
-            assert databag["database"] == database
+    @patch("relations.db.DbProvides.get_databags", return_value=[{}])
+    @patch(
+        "relations.backend_database.BackendDatabaseRequires.postgres_databag",
+        new_callable=PropertyMock,
+        return_value={},
+    )
+    @patch("relations.db.DbProvides._get_read_only_endpoint", return_value=None)
+    @patch("charm.PgBouncerK8sCharm.read_pgb_config", return_value=PgbConfig(DEFAULT_CONFIG))
+    @patch("charm.PgBouncerK8sCharm.render_pgb_config")
+    def test_update_postgres_endpoints(
+        self, _render_cfg, _read_cfg, _read_only_endpoint, _pg_databag, _get_databags
+    ):
+        database = "test_db"
+        _get_databags.return_value[0] = {"database": database}
+        _pg_databag.return_value = {"endpoints": "ip:port"}
+        cfg = _read_cfg.return_value
 
-        assert pgb_unit_databag["state"] == _state.return_value
+        relation = MagicMock()
+        reload_pgbouncer = False
 
-        _render_cfg.assert_called_with(_read_cfg.return_value, reload_pgbouncer=True)
+        self.db_relation.update_postgres_endpoints(relation, reload_pgbouncer)
+        assert database in cfg["databases"].keys()
+        assert f"{database}_standby" not in cfg["databases"].keys()
+        _render_cfg.assert_called_with(cfg, reload_pgbouncer=reload_pgbouncer)
+        _read_only_endpoint.return_value = "readonly:endpoint"
+
+        self.db_relation.update_postgres_endpoints(relation, reload_pgbouncer)
+        assert database in cfg["databases"].keys()
+        assert f"{database}_standby" in cfg["databases"].keys()
 
     @patch("relations.db.DbProvides.get_allowed_units", return_value="test_string")
     def test_on_relation_departed(self, _get_units):

--- a/tests/unit/relations/test_db.py
+++ b/tests/unit/relations/test_db.py
@@ -12,7 +12,6 @@ from constants import (
     DB_ADMIN_RELATION_NAME,
     DB_RELATION_NAME,
     PEER_RELATION_NAME,
-
 )
 from lib.charms.pgbouncer_k8s.v0.pgb import (
     DEFAULT_CONFIG,
@@ -203,7 +202,9 @@ class TestDb(unittest.TestCase):
         }
 
         standby_dbconnstrs = []
-        for standby_hostname in self.charm.peers.units_hostnames - {self.charm.peers.leader_hostname}:
+        for standby_hostname in self.charm.peers.units_hostnames - {
+            self.charm.peers.leader_hostname
+        }:
             standby_dbconnstr = dict(master_dbconnstr)
             standby_dbconnstr.update({"host": standby_hostname})
             standby_dbconnstrs.append(parse_dict_to_kv_string(standby_dbconnstr))

--- a/tests/unit/relations/test_peers.py
+++ b/tests/unit/relations/test_peers.py
@@ -22,11 +22,12 @@ class TestPeers(unittest.TestCase):
         self.unit = self.charm.unit.name
 
     @patch("relations.peers.Peers.app_databag", new_callable=PropertyMock)
+    @patch("relations.peers.Peers.unit_databag", new_callable=PropertyMock)
     @patch("charm.PgBouncerK8sCharm.render_pgb_config")
     @patch("charm.PgBouncerK8sCharm.render_auth_file")
     @patch("charm.PgBouncerK8sCharm.reload_pgbouncer")
     def test_on_peers_changed(
-        self, reload_pgbouncer, render_auth_file, render_pgb_config, app_databag
+        self, reload_pgbouncer, render_auth_file, render_pgb_config, unit_databag, app_databag
     ):
         databag = {}
         app_databag.return_value = databag

--- a/tests/unit/relations/test_peers.py
+++ b/tests/unit/relations/test_peers.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 from ops.testing import Harness
 
 from charm import PgBouncerK8sCharm
+from constants import BACKEND_RELATION_NAME
 from lib.charms.pgbouncer_k8s.v0.pgb import DEFAULT_CONFIG, PgbConfig
 from relations.peers import AUTH_FILE_DATABAG_KEY, CFG_FILE_DATABAG_KEY
 
@@ -32,6 +33,7 @@ class TestPeers(unittest.TestCase):
         databag = {}
         app_databag.return_value = databag
 
+        self.harness.add_relation(BACKEND_RELATION_NAME, "postgres")
         # We don't want to write anything if we're the leader
         self.harness.set_leader(True)
         self.charm.peers._on_changed(MagicMock())


### PR DESCRIPTION
## Proposal
Fixes endpoints to point to the correct units when scaling. 

## Context 
I forgot to update how master/standby endpoints are updated when adding scaling. This PR adds that in. 

## Testing
Updated unit tests, integration tests all pass fine. 
