### PR TITLE
DPE-781 Run integration tests for passed lint/unit tests only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,9 @@ jobs:
 
   integration-standalone:
     name: Integration tests for standalone charm (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -48,6 +51,9 @@ jobs:
 
   integration-backend:
     name: Integration tests for backend relation (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -69,6 +75,9 @@ jobs:
 
   integration-legacy-relations:
     name: Integration tests for legacy relations (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -90,6 +99,9 @@ jobs:
 
   integration-scaling:
     name: Integration tests for scaling pgbouncer (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,10 @@ jobs:
 
   integration-test:
     name: Integration tests
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Avoid a long-running integration test in case of failing gatekeeping tests. It will slightly increase the complete tests scope runtime but will save (a lot?) of electricity/money for Canonical as often new pull requests have some initial typos/issues to be polished.

## Proposal
DPE-781 Run integration tests for passed lint/unit tests only

## Context
Costs optimizations for long tests execution (c) John.

## Release Notes
Run integration tests for passed lint/unit tests only.

## Testing
Tested by GitHub action only.