### PR TITLE
Fix release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,12 +31,11 @@ jobs:
     name: Release to CharmHub
     needs:
       - lib-check
-      - lint
       - run-tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Select charmhub channel


### PR DESCRIPTION
`lint` was accidentally left in the release.yaml