### PR TITLE
Pin OS on release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
     needs:
       - lib-check
       - run-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Issue
As the `ubuntu-latest` GH runner image (it's still being updated on other places) was updated to jammy, the step that publishes the charm broke (due to using `--destructive-mode`).

We can see the issue on https://github.com/canonical/pgbouncer-k8s-operator/actions/runs/3687788578/jobs/6255386375.


# Solution
Pin focal runner image (`ubuntu-20.04`) on release workflow.


# Context
The bases on `charmcraft.yaml` weren't updated to jammy as there are some issues related to some python wheels that should be solved when the work to move the charm to jammy is done.


# Testing
Tested `sudo charmcraft pack --destructive-mode --quiet` manually on a focal VM.


# Release Notes
Pin focal runner image on release workflow.