### PR TITLE
set pgbouncer container to focal branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run linters
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
     needs:
       - lib-check
       - run-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.1.0
         with:
-          resource-overrides: "pgbouncer-image:2"
+          resource-overrides: "pgbouncer-image:1.12-20.04"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ charmcraft pack
 
 ```bash
 juju deploy ./pgbouncer-k8s_ubuntu-20.04-amd64.charm \
-    --resource pgbouncer-image=dataplatformoci/pgbouncer:latest
+    --resource pgbouncer-image=dataplatformoci/pgbouncer:1.12-20.04
 ```
 
 ## Canonical Contributor Agreement

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,7 +25,7 @@ resources:
   pgbouncer-image:
     type: oci-image
     description: OCI image for pgbouncer
-    upstream-source: docker.io/dataplatformoci/pgbouncer:latest
+    upstream-source: docker.io/dataplatformoci/pgbouncer:1.12-20.04
 
 provides:
   database:


### PR DESCRIPTION
## Proposal
The `pgbouncer:latest` container has been updated to jammy, so this is a quick PR to pin this to the new pinned focal version. 

## Testing
PR is currently running tests, but there are no meaningful changes in this container between the previous focal version, other than no pgbackrest. 
