### PR TITLE
Multiple pgbouncer application instances in pebble

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,6 @@ jobs:
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.1.0
         with:
-          resource-overrides: "pgbouncer-image:3"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"

--- a/src/charm.py
+++ b/src/charm.py
@@ -25,6 +25,7 @@ from constants import (
     PG_GROUP,
     PG_USER,
     PGB,
+    PGB_DIR,
 )
 from relations.backend_database import BackendDatabaseRequires
 from relations.db import DbProvides
@@ -54,6 +55,15 @@ class PgBouncerK8sCharm(CharmBase):
         self.legacy_db_admin_relation = DbProvides(self, admin=True)
 
         self._cores = os.cpu_count()
+        self._services = [
+            {
+                "name": f"{PGB}_{service_id}",
+                "id": service_id,
+                "dir": f"{PGB_DIR}/instance_{service_id}",
+                "ini_path": f"{PGB_DIR}/instance_{service_id}/pgbouncer.ini",
+            }
+            for service_id in range(self._cores)
+        ]
 
     # =======================
     #  Charm Lifecycle Hooks
@@ -135,25 +145,27 @@ class PgBouncerK8sCharm(CharmBase):
     def _pgbouncer_layer(self) -> Layer:
         """Returns a default pebble config layer for the pgbouncer container.
 
-        TODO auto-generate multiple pgbouncer services to make use of available cpu cores on unit.
+        Auto-generates multiple pgbouncer services to make use of available cpu cores on unit.
 
         Returns:
             A pebble configuration layer for charm services.
         """
+        pebble_services = {}
+        for service in self._services:
+            pebble_services[service["name"]] = {
+                "summary": f"pgbouncer service {service['id']}",
+                "user": PG_USER,
+                "group": PG_GROUP,
+                # -R flag reuses sockets on restart
+                "command": f"pgbouncer -R {service['ini_path']}",
+                "startup": "enabled",
+                "override": "replace",
+            }
+
         return {
             "summary": "pgbouncer layer",
             "description": "pebble config layer for pgbouncer",
-            "services": {
-                PGB: {
-                    "summary": "pgbouncer service",
-                    "user": PG_USER,
-                    "group": PG_GROUP,
-                    # -R flag reuses sockets on restart
-                    "command": f"pgbouncer -R {INI_PATH}",
-                    "startup": "enabled",
-                    "override": "replace",
-                }
-            },
+            "services": pebble_services,
         }
 
     def _on_update_status(self, _) -> None:
@@ -196,17 +208,19 @@ class PgBouncerK8sCharm(CharmBase):
         Raises:
             ops.pebble.ConnectionError if pgb service isn't accessible
         """
-        pgb_container = self.unit.get_container(PGB)
-        services = pgb_container.get_services()
-        if PGB not in services.keys():
-            # pebble_ready event hasn't fired so pgbouncer has not been added to pebble config
-            # TODO update error handling across the charm so we aren't constantly swapping
-            # deferred hooks around
-            raise ConnectionError
-
         self.unit.status = MaintenanceStatus("Reloading Pgbouncer")
         logger.info("reloading pgbouncer application")
-        pgb_container.restart(PGB)
+
+        pgb_container = self.unit.get_container(PGB)
+        pebble_services = pgb_container.get_services()
+        for service in self._services:
+            if service["name"] not in pebble_services.keys():
+                # pebble_ready event hasn't fired so pgbouncer has not been added to pebble config
+                # TODO update error handling across the charm so we aren't constantly swapping
+                # deferred hooks around
+                raise ConnectionError
+            pgb_container.restart(service["name"])
+
         self.check_pgb_running()
 
     def check_pgb_running(self):
@@ -216,20 +230,20 @@ class PgBouncerK8sCharm(CharmBase):
             pebble.ConnectionError if pgbouncer hasn't been added to pebble config.
         """
         pgb_container = self.unit.get_container(PGB)
-        services = pgb_container.get_services()
-        if PGB not in services.keys():
-            # pebble_ready event hasn't fired so pgbouncer layer has not been added to pebble
-            raise ConnectionError
+        pebble_services = pgb_container.get_services()
+        for service in self._services:
+            if service["name"] not in pebble_services.keys():
+                # pebble_ready event hasn't fired so pgbouncer layer has not been added to pebble
+                raise ConnectionError
+            pgb_service_status = pgb_container.get_services().get(service["name"]).current
+            if pgb_service_status != ServiceStatus.ACTIVE:
+                pgb_not_running = f"PgBouncer service {service['name']} not running"
+                self.unit.status = BlockedStatus(pgb_not_running)
+                logger.error(pgb_not_running)
+                return False
 
-        pgb_service_status = pgb_container.get_services(PGB).get(PGB).current
-        if pgb_service_status == ServiceStatus.ACTIVE:
-            self.unit.status = ActiveStatus()
-            return True
-        else:
-            pgb_not_running = "PgBouncer not running"
-            self.unit.status = BlockedStatus(pgb_not_running)
-            logger.error(pgb_not_running)
-            return False
+        self.unit.status = ActiveStatus()
+        return True
 
     # =================
     #  File Management
@@ -322,10 +336,17 @@ class PgBouncerK8sCharm(CharmBase):
             # config doesn't exist on local filesystem, so update it.
             pass
 
-        self.push_file(INI_PATH, config.render(), 0o400)
-        logger.info("pushed new pgbouncer.ini config file to pgbouncer container")
-
         self.peers.update_cfg(config)
+
+        perm = 0o400
+        self.push_file(INI_PATH, config.render(), perm)
+        for service in self._services:
+            s_config = pgb.PgbConfig(config)
+            s_config[PGB]["unix_socket_dir"] = service["dir"]
+            s_config[PGB]["logfile"] = f"{service['dir']}/pgbouncer.log"
+            s_config[PGB]["pidfile"] = f"{service['dir']}/pgbouncer.pid"
+            self.push_file(service["ini_path"], s_config.render(), perm)
+        logger.info("pushed new pgbouncer.ini config files to pgbouncer container")
 
         if reload_pgbouncer:
             self.reload_pgbouncer()

--- a/src/charm.py
+++ b/src/charm.py
@@ -95,6 +95,17 @@ class PgBouncerK8sCharm(CharmBase):
                 event.defer()
                 return
 
+        # Initialise filesystem - _push_file()'s make_dirs option sets the permissions for those
+        # dirs to root, so we build them ourselves to control permissions.
+        for service in self._services:
+            if not container.exists(service["dir"]):
+                container.make_dir(
+                    service["dir"],
+                    user=PG_USER,
+                    group=PG_USER,
+                    permissions=0o700,
+                )
+
         self.render_pgb_config(config)
 
         try:

--- a/src/constants.py
+++ b/src/constants.py
@@ -10,7 +10,6 @@ PG = PG_USER = PG_GROUP = "postgres"
 PGB_DIR = "/var/lib/postgresql/pgbouncer"
 INI_PATH = f"{PGB_DIR}/pgbouncer.ini"
 AUTH_FILE_PATH = f"{PGB_DIR}/userlist.txt"
-LOG_PATH = f"{PGB_DIR}/pgbouncer.log"
 
 PEER_RELATION_NAME = "pgb-peers"
 BACKEND_RELATION_NAME = "backend-database"

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -12,7 +12,7 @@ from charms.pgbouncer_k8s.v0 import pgb
 from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
-from constants import AUTH_FILE_PATH, INI_PATH, LOG_PATH
+from constants import AUTH_FILE_PATH, INI_PATH
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 PGB = METADATA["name"]
@@ -94,11 +94,6 @@ async def get_cfg(ops_test: OpsTest, unit_name: str) -> pgb.PgbConfig:
     """Gets pgbouncer config from pgbouncer container."""
     cat = await cat_file_from_unit(ops_test, INI_PATH, unit_name)
     return pgb.PgbConfig(cat)
-
-
-async def get_pgb_log(ops_test: OpsTest, unit_name) -> str:
-    """Gets pgbouncer logs from pgbouncer container."""
-    return await cat_file_from_unit(ops_test, LOG_PATH, unit_name)
 
 
 async def get_userlist(ops_test: OpsTest, unit_name) -> str:

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -106,6 +106,26 @@ async def get_userlist(ops_test: OpsTest, unit_name) -> str:
     return await cat_file_from_unit(ops_test, AUTH_FILE_PATH, unit_name)
 
 
+async def run_command_on_unit(ops_test: OpsTest, unit_name: str, command: str) -> str:
+    """Run a command on a specific unit.
+
+    Args:
+        ops_test: The ops test framework instance
+        unit_name: The name of the unit to run the command on
+        command: The command to run
+
+    Returns:
+        the command output if it succeeds, otherwise raises an exception.
+    """
+    complete_command = f"ssh --container pgbouncer {unit_name} {command}"
+    return_code, stdout, _ = await ops_test.juju(*complete_command.split())
+    if return_code != 0:
+        raise Exception(
+            "Expected command %s to succeed instead it failed: %s", command, return_code
+        )
+    return stdout
+
+
 async def cat_file_from_unit(ops_test: OpsTest, filepath: str, unit_name: str) -> str:
     """Gets a file from the pgbouncer container of a pgbouncer application unit."""
     cat_cmd = f"ssh --container pgbouncer {unit_name} cat {filepath}"

--- a/tests/integration/relations/test_backend_database.py
+++ b/tests/integration/relations/test_backend_database.py
@@ -15,7 +15,6 @@ from tests.integration.helpers.helpers import (
     get_backend_relation,
     get_backend_user_pass,
     get_cfg,
-    get_pgb_log,
     get_userlist,
     scale_application,
     wait_for_relation_joined_between,
@@ -101,7 +100,6 @@ async def test_relate_pgbouncer_to_postgres(ops_test: OpsTest):
 
         cfg = await get_cfg(ops_test, f"{PGB}/0")
         logging.info(cfg.render())
-        logger.info(await get_pgb_log(ops_test, f"{PGB}/0"))
 
 
 @pytest.mark.backend

--- a/tests/integration/relations/test_db.py
+++ b/tests/integration/relations/test_db.py
@@ -14,7 +14,6 @@ from tests.integration.helpers.helpers import (
     get_backend_user_pass,
     get_cfg,
     get_legacy_relation_username,
-    get_pgb_log,
     wait_for_relation_joined_between,
     wait_for_relation_removed_between,
 )
@@ -163,5 +162,3 @@ async def test_create_db_legacy_relation(ops_test: OpsTest):
         assert finos_user not in cfg["pgbouncer"]["admin_users"]
         assert "waltz" not in cfg["databases"].keys()
         assert "waltz_standby" not in cfg["databases"].keys()
-
-        logger.info(await get_pgb_log(ops_test, f"{PGB}/0"))

--- a/tests/integration/relations/test_db_admin.py
+++ b/tests/integration/relations/test_db_admin.py
@@ -12,7 +12,6 @@ from pytest_operator.plugin import OpsTest
 from tests.integration.helpers.helpers import (
     get_backend_user_pass,
     get_legacy_relation_username,
-    get_pgb_log,
     wait_for_relation_joined_between,
 )
 from tests.integration.helpers.postgresql_helpers import (
@@ -164,5 +163,3 @@ async def test_create_db_admin_legacy_relation(ops_test: OpsTest):
             pg_user=pgb_user,
             pg_user_password=pgb_password,
         )
-
-        logger.info(await get_pgb_log(ops_test, f"{PGB}/0"))

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -55,7 +55,6 @@ async def test_multiple_pebble_services(ops_test: OpsTest):
     unit = ops_test.model.applications[PGB].units[0]
     core_count = await run_command_on_unit(ops_test, unit.name, "nproc --all")
     get_services = await run_command_on_unit(ops_test, unit.name, "/charm/bin/pebble services")
-    logger.error(get_services)
 
     services = get_services.splitlines()[1:]
     assert len(services) == int(core_count)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.helpers.helpers import get_cfg
+from tests.integration.helpers.helpers import get_cfg, run_command_on_unit
 
 logger = logging.getLogger(__name__)
 
@@ -47,3 +47,20 @@ async def test_config_updates(ops_test: OpsTest):
         logger.info(cfg)
         logger.info(await pgbouncer_app.get_config())
         assert cfg["pgbouncer"]["listen_port"] == port
+
+
+@pytest.mark.standalone
+async def test_multiple_pebble_services(ops_test: OpsTest):
+    """Test we have the correct pebble services."""
+    unit = ops_test.model.applications[PGB].units[0]
+    core_count = await run_command_on_unit(ops_test, unit.name, "nproc --all")
+    get_services = await run_command_on_unit(ops_test, unit.name, "/charm/bin/pebble services")
+    logger.error(get_services)
+
+    services = get_services.splitlines()[1:]
+    assert len(services) == int(core_count)
+
+    for service in services:
+        service = service.split()
+        assert service[1] == "enabled"
+        assert service[2] == "active"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -21,7 +21,8 @@ class TestCharm(unittest.TestCase):
         self.harness.begin_with_initial_hooks()
         self.charm = self.harness.charm
 
-    def test_on_start(self):
+    @patch("ops.model.Container.make_dir")
+    def test_on_start(self, _mkdir):
         self.harness.add_relation(BACKEND_RELATION_NAME, "postgres")
         self.harness.set_leader(True)
         self.charm.on.start.emit()
@@ -33,8 +34,11 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.PgBouncerK8sCharm.update_client_connection_info")
     @patch("ops.model.Container.restart")
+    @patch("ops.model.Container.make_dir")
     @patch("charm.PgBouncerK8sCharm.check_pgb_running")
-    def test_on_config_changed(self, _check_pgb_running, _restart, _update_connection_info):
+    def test_on_config_changed(
+        self, _check_pgb_running, _mkdir, _restart, _update_connection_info
+    ):
         self.harness.add_relation(BACKEND_RELATION_NAME, "postgres")
         self.harness.set_leader(True)
         self.charm.on.start.emit()
@@ -91,7 +95,8 @@ class TestCharm(unittest.TestCase):
         layer = self.charm._pgbouncer_layer()
         assert len(layer["services"]) == self.charm._cores
 
-    def test_on_pgbouncer_pebble_ready(self):
+    @patch("ops.model.Container.make_dir")
+    def test_on_pgbouncer_pebble_ready(self, _mkdir):
         self.harness.add_relation(BACKEND_RELATION_NAME, "postgres")
         self.harness.set_leader(True)
         # emit on start to ensure config file render
@@ -133,8 +138,9 @@ class TestCharm(unittest.TestCase):
         read_cfg = self.charm.read_pgb_config()
         self.assertEqual(PgbConfig(read_cfg).render(), test_cfg.render())
 
+    @patch("ops.model.Container.make_dir")
     @patch("ops.model.Container.restart")
-    def test_reload_pgbouncer(self, _restart):
+    def test_reload_pgbouncer(self, _restart, _mkdir):
         self.harness.add_relation(BACKEND_RELATION_NAME, "postgres")
         self.harness.set_leader(True)
         # necessary hooks before we can check reloads


### PR DESCRIPTION
## Proposal
This PR uses pebble to implement multiple pgbouncer instances. 

## Context
Pgbouncer is single-threaded. The accepted way to make use of this is to have multiple pgbouncer instances - one per core. On kubernetes, this could also be mitigated by only deploying containers with one CPU core.

## Release Notes
- Implements multiple pgbouncer instances, one per core on each unit.

## Testing
- Added an integrated test that verifies the instances are all running as expected. 
