### PR TITLE
Fix relation with OpenLDAP

### DIFF
--- a/lib/charms/pgbouncer_k8s/v0/pgb.py
+++ b/lib/charms/pgbouncer_k8s/v0/pgb.py
@@ -38,7 +38,7 @@ LIBID = "113f4a7480c04631bfdf5fe776f760cd"
 LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ DEFAULT_CONFIG = {
         "auth_type": "md5",
         "user": "postgres",
         "max_client_conn": "10000",
-        "ignore_startup_parameters": "extra_float_digits",
+        "ignore_startup_parameters": "extra_float_digits,options",
         "server_tls_sslmode": "prefer",
         "so_reuseport": "1",
         "unix_socket_dir": PGB_DIR,

--- a/lib/charms/pgbouncer_k8s/v0/pgb.py
+++ b/lib/charms/pgbouncer_k8s/v0/pgb.py
@@ -100,7 +100,7 @@ class PgbConfig(MutableMapping):
     auth_type = md5
     user = postgres
     max_client_conn = 10000
-    ignore_startup_parameters = extra_float_digits
+    ignore_startup_parameters = extra_float_digits,options
     server_tls_sslmode = prefer
     so_reuseport = 1
     unix_socket_dir = /var/lib/postgresql/pgbouncer

--- a/tests/integration/relations/test_db.py
+++ b/tests/integration/relations/test_db.py
@@ -27,6 +27,7 @@ PGB = METADATA["name"]
 PG = "postgresql-k8s"
 FINOS_WALTZ = "finos-waltz"
 ANOTHER_FINOS_WALTZ = "another-finos-waltz"
+OPENLDAP = "openldap"
 
 logger = logging.getLogger(__name__)
 
@@ -162,3 +163,14 @@ async def test_create_db_legacy_relation(ops_test: OpsTest):
         assert finos_user not in cfg["pgbouncer"]["admin_users"]
         assert "waltz" not in cfg["databases"].keys()
         assert "waltz_standby" not in cfg["databases"].keys()
+
+
+@pytest.mark.legacy_relation
+async def test_relation_with_openldap(ops_test: OpsTest):
+    """Test the relation with OpenLDAP charm."""
+    await ops_test.model.deploy(
+        "openldap-charmers-openldap", application_name=OPENLDAP, channel="edge"
+    )
+    await ops_test.model.add_relation(f"{PGB}:db", f"{OPENLDAP}:db")
+    wait_for_relation_joined_between(ops_test, PGB, OPENLDAP)
+    await ops_test.model.wait_for_idle(apps=[PG, PGB, OPENLDAP], status="active", timeout=1000)


### PR DESCRIPTION
## Proposal
Jira issue: [DPE-1037](https://warthogs.atlassian.net/browse/DPE-1037)
OpenLDAP fails with an error when related to the PgBouncer charm.
```
openldap/0*       error     idle   10.1.150.242  389/TCP  crash loop backoff: back-off 5m0s restarting failed container=openldap pod=openldap-5449dfd7cb-jslhn_microk8s(a795f914-79b3-48f4-9b80-4dfbb4234025)
```

## Context
The error is due to some parameters not supported by PgBouncer. As PgBouncer offer the possibility to ignore unsupported parameters by listing them on the `ignore_startup_parameters` field from the PgBouncer config file, it was added there.

## Release Notes
Ignore OpenLDAP charm `options` parameter.

## Testing
Tested manually and saw that the charm is deployed correctly and no error happens (haven't checked too deep to see the where the unsupported parameters are used inside OpenLDAP).

I also tested with and older revision of the PgBouncer charm (ignoring the `options` parameter) and no errors were raised. Taking to Dragomir, probably the `permission denied` error happened when he mangled the postgresql cluster beneath at some point while relating the charms.

Also added an integration test that deploys and checks that the OpenLDAP charm hasn't crashed.


[DPE-1037]: https://warthogs.atlassian.net/browse/DPE-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ