### PR TITLE
Move libraries check to ci.yaml and add libraries release step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,24 @@ jobs:
       - name: Run tests
         run: tox -e unit
 
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@2.2.2
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   integration-standalone:
     name: Integration tests for standalone charm
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest
@@ -53,6 +68,7 @@ jobs:
   integration-backend:
     name: Integration tests for backend relation
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest
@@ -77,6 +93,7 @@ jobs:
   integration-legacy-client-relations:
     name: Integration tests for legacy client relations
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest
@@ -101,6 +118,7 @@ jobs:
   integration-client-relations:
     name: Integration tests for updated client relations
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest
@@ -125,6 +143,7 @@ jobs:
   integration-scaling:
     name: Integration tests for scaling pgbouncer
     needs:
+      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,26 +6,10 @@ on:
       - main
 
 jobs:
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.1.1
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-
   run-tests:
     name: Run lint, unit, and integration tests
-    needs:
-      - lib-check
     uses: ./.github/workflows/ci.yaml
+    secrets: inherit
 
   release-to-charmhub:
     name: Release to CharmHub
@@ -39,10 +23,15 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.1.1
+        uses: canonical/charming-actions/channel@2.2.2
         id: channel
+      - name: Release any bumped charm libs
+        uses: canonical/charming-actions/release-libraries@2.2.0
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.1.1
+        uses: canonical/charming-actions/upload-charm@2.2.2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: canonical/charming-actions/channel@2.2.2
         id: channel
       - name: Release any bumped charm libs
-        uses: canonical/charming-actions/release-libraries@2.2.0
+        uses: canonical/charming-actions/release-libraries@2.2.2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Proposal
Jira ticket: [DPE-1232](https://warthogs.atlassian.net/browse/DPE-1232)
Enable the process that releases new libraries versions to Charmhub and check outdated libraries on PRs.

## Context
Similar to what was implemented on https://github.com/canonical/postgresql-k8s-operator/pull/84.

## Release Notes
Move libraries check to ci.yaml and add libraries release step.

[DPE-1232]: https://warthogs.atlassian.net/browse/DPE-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ