### PR TITLE
Upgrade to jammy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Release to CharmHub
     needs:
       - run-tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,13 +59,13 @@ Build the charm in this git repository using:
 charmcraft pack
 ```
 
-This will generate a file called something like `pgbouncer-k8s_ubuntu-20.04-amd64.charm`. The `20.04` component of this filename relates to the **ubuntu version used in the build container used to build the charm**, designated by the `build-on` parameter in `./metadata.yaml`. It does not relate to the ubuntu version of the charm.
+This will generate a file called something like `pgbouncer-k8s_ubuntu-22.04-amd64.charm`. The `22.04` component of this filename relates to the **ubuntu version used in the build container used to build the charm**, designated by the `build-on` parameter in `./metadata.yaml`. It does not relate to the ubuntu version of the charm.
 
 ### Deploy
 
 ```bash
 # This .charm file was built using the default `charmcraft pack` command.
-juju deploy ./pgbouncer-k8s_ubuntu-20.04-amd64.charm \
+juju deploy ./pgbouncer-k8s_ubuntu-22.04-amd64.charm \
     --resource pgbouncer-image=dataplatformoci/pgbouncer:1.16-22.04
 ```
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,10 +5,10 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
 
 parts:
   charm:

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -20,6 +20,7 @@ from tenacity import (
 
 from constants import AUTH_FILE_PATH, INI_PATH
 
+CHARM_SERIES = "jammy"
 CLIENT_APP_NAME = "application"
 PGB_METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 PGB = PGB_METADATA["name"]

--- a/tests/integration/relations/pgbouncer_provider/application-charm/charmcraft.yaml
+++ b/tests/integration/relations/pgbouncer_provider/application-charm/charmcraft.yaml
@@ -5,10 +5,10 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
 
 
 parts:

--- a/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
+++ b/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
@@ -13,6 +13,7 @@ from pytest_operator.plugin import OpsTest
 from constants import BACKEND_RELATION_NAME
 
 from ...helpers.helpers import (
+    CHARM_SERIES,
     get_app_relation_databag,
     get_backend_relation,
     get_backend_user_pass,
@@ -63,12 +64,14 @@ async def test_database_relation_with_charm_libraries(
         ops_test.model.deploy(
             application_charm,
             application_name=CLIENT_APP_NAME,
+            series=CHARM_SERIES,
         ),
         ops_test.model.deploy(
             pgb_charm,
             resources=PGB_RESOURCES,
             application_name=PGB,
             num_units=2,
+            series=CHARM_SERIES,
         ),
         ops_test.model.deploy(
             PG,
@@ -244,6 +247,7 @@ async def test_each_relation_has_unique_credentials(ops_test: OpsTest, applicati
     await ops_test.model.deploy(
         application_charm,
         application_name=SECONDARY_CLIENT_APP_NAME,
+        series=CHARM_SERIES,
     )
     await ops_test.model.wait_for_idle(status="active", apps=all_app_names)
 
@@ -336,6 +340,7 @@ async def test_multiple_pgb_can_connect_to_one_backend(ops_test: OpsTest, pgb_ch
         pgb_charm,
         resources=PGB_RESOURCES,
         application_name=pgb_secondary,
+        series=CHARM_SERIES,
     )
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[pgb_secondary], status="blocked"),

--- a/tests/integration/relations/test_backend_database.py
+++ b/tests/integration/relations/test_backend_database.py
@@ -11,6 +11,7 @@ from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 from ..helpers.helpers import (
+    CHARM_SERIES,
     get_app_relation_databag,
     get_backend_relation,
     get_backend_user_pass,
@@ -52,6 +53,7 @@ async def test_relate_pgbouncer_to_postgres(ops_test: OpsTest):
                 charm,
                 resources=resources,
                 application_name=PGB,
+                series=CHARM_SERIES,
             ),
             # Edge 5 is the new postgres charm
             ops_test.model.deploy(PG, channel="edge", trust=True, num_units=3),

--- a/tests/integration/relations/test_backend_database.py
+++ b/tests/integration/relations/test_backend_database.py
@@ -118,7 +118,7 @@ async def test_tls_encrypted_connection_to_postgres(ops_test: OpsTest):
 
         # Deploy TLS Certificates operator.
         config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
-        await ops_test.model.deploy(TLS, channel="beta", config=config)
+        await ops_test.model.deploy(TLS, config=config)
         await ops_test.model.wait_for_idle(apps=[TLS], status="active", timeout=1000)
 
         # Relate it to the PostgreSQL to enable TLS.

--- a/tests/integration/relations/test_db.py
+++ b/tests/integration/relations/test_db.py
@@ -9,6 +9,7 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 from ..helpers.helpers import (
+    CHARM_SERIES,
     get_app_relation_databag,
     get_backend_user_pass,
     get_cfg,
@@ -46,6 +47,7 @@ async def test_create_db_legacy_relation(ops_test: OpsTest):
                 resources=resources,
                 application_name=PGB,
                 num_units=3,
+                series=CHARM_SERIES,
             ),
             ops_test.model.deploy(PG, num_units=3, trust=True, channel="edge"),
             ops_test.model.deploy("finos-waltz-k8s", application_name=FINOS_WALTZ, channel="edge"),

--- a/tests/integration/relations/test_db_admin.py
+++ b/tests/integration/relations/test_db_admin.py
@@ -9,6 +9,7 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 from ..helpers.helpers import (
+    CHARM_SERIES,
     get_backend_user_pass,
     get_legacy_relation_username,
     wait_for_relation_joined_between,
@@ -42,6 +43,7 @@ async def test_create_db_admin_legacy_relation(ops_test: OpsTest):
                 charm,
                 resources=resources,
                 application_name=PGB,
+                series=CHARM_SERIES,
             ),
             ops_test.model.deploy(PG, trust=True, num_units=3, channel="edge"),
             ops_test.model.deploy(

--- a/tests/integration/relations/test_peers.py
+++ b/tests/integration/relations/test_peers.py
@@ -10,6 +10,7 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 from ..helpers.helpers import (
+    CHARM_SERIES,
     scale_application,
     wait_for_relation_joined_between,
     wait_for_relation_removed_between,
@@ -33,7 +34,9 @@ async def test_deploy_at_scale(ops_test):
         "pgbouncer-image": METADATA["resources"]["pgbouncer-image"]["upstream-source"],
     }
     async with ops_test.fast_forward():
-        await ops_test.model.deploy(charm, resources=resources, application_name=PGB, num_units=3)
+        await ops_test.model.deploy(
+            charm, resources=resources, application_name=PGB, num_units=3, series=CHARM_SERIES
+        )
         await ops_test.model.wait_for_idle(
             apps=[PGB], status="blocked", timeout=1000, wait_for_exact_units=3
         ),

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from .helpers.helpers import get_cfg, run_command_on_unit
+from .helpers.helpers import CHARM_SERIES, get_cfg, run_command_on_unit
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +29,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
             charm,
             resources=resources,
             application_name=PGB,
+            series=CHARM_SERIES,
         )
         await ops_test.model.wait_for_idle(apps=[PGB], status="blocked", timeout=1000)
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -82,7 +82,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         wait_for_apps = True
         # Deploy TLS Certificates operator.
         config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
-        await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="beta", config=config)
+        await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, config=config)
         # Relate it to the PgBouncer to enable TLS.
         await ops_test.model.relate(PGB, TLS_CERTIFICATES_APP_NAME)
         await ops_test.model.relate(TLS_CERTIFICATES_APP_NAME, POSTGRESQL_APP_NAME)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -5,6 +5,7 @@ import pytest as pytest
 from pytest_operator.plugin import OpsTest
 
 from .helpers.helpers import (
+    CHARM_SERIES,
     CLIENT_APP_NAME,
     PGB,
     PGB_METADATA,
@@ -39,6 +40,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
                 },
                 application_name=PGB,
                 num_units=APPLICATION_UNITS,
+                series=CHARM_SERIES,
             )
 
     if not await app_name(ops_test, CLIENT_APP_NAME):
@@ -50,6 +52,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
             await ops_test.model.deploy(
                 application_charm,
                 application_name=CLIENT_APP_NAME,
+                series=CHARM_SERIES,
             )
     # remove preexisting relation if any so that we can know the rel id
     relations = [


### PR DESCRIPTION
# Issue
Jira issue: [DPE-1480](https://warthogs.atlassian.net/browse/DPE-1480)
The charm is still on Focal (and the OCI image is already on Jammy).


# Solution
Upgrade all the bases and all the deployments to use Jammy.


# Context
The TLS Certificates Operator deployed in the tests had its channel changed to stable, as now we have it.


# Testing
Used the existing tests to confirm that the charm works on Jammy.


# Release Notes
Upgrade charm to Jammy.

[DPE-1480]: https://warthogs.atlassian.net/browse/DPE-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ