### PR TITLE
Update OCI due to outdated packages

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,7 +26,7 @@ resources:
     type: oci-image
     description: OCI image for pgbouncer
     # Rock version, using pgbouncer v1.18.
-    upstream-source: ghcr.io/canonical/charmed-postgresql@sha256:c1f77c6b95a487d9e1de59dbb0eac6ec61a6493901d9d33355f98ccce9d74486
+    upstream-source: ghcr.io/canonical/charmed-postgresql@sha256:218f28d148e729a257930c7f073755275cf7830ff666314e530dfdd537056572
 
 provides:
   database:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,7 +26,7 @@ resources:
     type: oci-image
     description: OCI image for pgbouncer
     # Rock version, using pgbouncer v1.18.
-    upstream-source: ghcr.io/canonical/charmed-postgresql@sha256:218f28d148e729a257930c7f073755275cf7830ff666314e530dfdd537056572
+    upstream-source: ghcr.io/canonical/charmed-postgresql@sha256:137323ff550d310a7f004561b1df90494b8ba6e344397dea2c6cb9c049b22f5b
 
 provides:
   database:


### PR DESCRIPTION
## Issue
Security scan report:
```
Revision r61 (amd64; channels: 14/edge)
 * libc-ares2: 6164-1
```

## Solution
Rebuild and update rock