### PR TITLE
[DPE-2334] Use hashed password for auth user

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,7 +15,7 @@ source: |
 issues: |
   https://github.com/canonical/pgbouncer-k8s-operator/issues
 maintainers:
-  "Will Fitch <will.fitch@canonical.com>"
+  - Canonical Data Platform <data-platform@lists.launchpad.net>
 
 containers:
   pgbouncer:

--- a/src/charm.py
+++ b/src/charm.py
@@ -26,6 +26,7 @@ from ops.pebble import ConnectionError, Layer, PathError, ServiceStatus
 from constants import (
     AUTH_FILE_PATH,
     CLIENT_RELATION_NAME,
+    EXTENSIONS_BLOCKING_MESSAGE,
     INI_PATH,
     METRICS_PORT,
     MONITORING_PASSWORD_KEY,
@@ -301,6 +302,9 @@ class PgBouncerK8sCharm(CharmBase):
 
         if not self.backend.ready:
             self.unit.status = BlockedStatus("backend database relation not ready")
+            return
+
+        if self.unit.status.message == EXTENSIONS_BLOCKING_MESSAGE:
             return
 
         try:

--- a/src/relations/backend_database.py
+++ b/src/relations/backend_database.py
@@ -240,11 +240,11 @@ class BackendDatabaseRequires(Object):
             return
 
         plaintext_password = pgb.generate_password()
+        hashed_password = pgb.get_hashed_password(self.auth_user, plaintext_password)
         # create authentication user on postgres database, so we can authenticate other users
         # later on
-        self.postgres.create_user(self.auth_user, plaintext_password, admin=True)
+        self.postgres.create_user(self.auth_user, hashed_password, admin=True)
         self.initialise_auth_function([self.database.database, PG])
-        hashed_password = pgb.get_hashed_password(self.auth_user, plaintext_password)
 
         # Add the monitoring user.
         if not (

--- a/tests/integration/relations/test_db.py
+++ b/tests/integration/relations/test_db.py
@@ -153,7 +153,7 @@ async def test_create_db_legacy_relation(ops_test: OpsTest, pgb_charm):
         assert "waltz_standby" in cfg["databases"].keys()
 
         # Remove the first deployment of Finos Waltz.
-        await ops_test.model.remove_application(FINOS_WALTZ)
+        await ops_test.model.remove_application(FINOS_WALTZ, block_until_done=True)
         wait_for_relation_removed_between(ops_test, PGB, FINOS_WALTZ)
         await ops_test.model.wait_for_idle(apps=[PGB, PG], status="active", timeout=1000)
 
@@ -198,6 +198,7 @@ async def test_relation_with_indico(ops_test: OpsTest):
         == EXTENSIONS_BLOCKING_MESSAGE
     )
     await ops_test.model.applications[PGB].destroy_relation(f"{PGB}:db", "indico:db")
+    await ops_test.model.wait_for_idle(apps=[PGB], status="active", idle_period=15)
 
     logger.info("Rerelate with extensions enabled")
     config = {"plugin_pg_trgm_enable": "True", "plugin_unaccent_enable": "True"}

--- a/tests/unit/relations/test_backend_database.py
+++ b/tests/unit/relations/test_backend_database.py
@@ -85,11 +85,11 @@ class TestBackendDatabaseRelation(unittest.TestCase):
         mock_event = MagicMock()
         mock_event.username = "mock_user"
         self.backend._on_database_created(mock_event)
+        hash_pw = get_hashed_password(self.backend.auth_user, pw)
 
-        postgres.create_user.assert_called_with(self.backend.auth_user, pw, admin=True)
+        postgres.create_user.assert_called_with(self.backend.auth_user, hash_pw, admin=True)
         _init_auth.assert_has_calls([call([self.backend.database.database, "postgres"])])
 
-        hash_pw = get_hashed_password(self.backend.auth_user, pw)
         hash_mon_pw = get_hashed_password(self.backend.stats_user, pw)
         _render_auth_file.assert_any_call(
             f'"{self.backend.auth_user}" "{hash_pw}"\n"{self.backend.stats_user}" "{hash_mon_pw}"'


### PR DESCRIPTION
## Issue
Connection to PgBouncer in a cross-model relation (with PostgreSQL VM charm) is not working due to different password encryption algorithms used.

## Solution
Implement the same approach from https://github.com/canonical/pgbouncer-operator/pull/56 to fix it. One adjustment was made in the charm to avoid overriding the blocked status related to the extensions message.

Also, on https://github.com/canonical/postgresql-k8s-operator/pull/215 the password encryption was changed on PostgreSQL k8s charm to improve security.

Currently, the unique options to improve the security of the password of the PgBouncer auth user is to use something like SSL certificates (as mentioned on https://github.com/pgbouncer/pgbouncer/issues/774#issuecomment-1305769441). The other approaches mentioned in the same comment are either more insecure (plain text password) or need that we establish a connection from inside this charm with the auth user before almost all the connections made by clients (which seems to be impractical).

Fixes https://github.com/canonical/pgbouncer-k8s-operator/issues/122 (I tested this fix with the instructions from the issue to confirm that the issue is fixed).