### PR TITLE
[DPE-2676] Update readme to reflect the actual readonly endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ As this charm is not yet published, you need to follow the build and deploy inst
   - Makes use of the [data-platform-libs DatabaseRequires library](https://github.com/canonical/data-platform-libs/blob/main/lib/charms/data_platform_libs/v0/database_provides.py).
 - `database:postgresql-client`
   - Provides a relation to client applications.
-  - Importantly, this relation doesn't handle scaling the same way others do. All PgBouncer nodes are read/writes, and they expose the read-only nodes of the backend database through the database name `f"{dbname}_standby"`.
+  - Importantly, this relation doesn't handle scaling the same way others do. All PgBouncer nodes are read/writes, and they expose the read-only nodes of the backend database through the database name `f"{dbname}_readonly"`.
 
 The expected data presented in a relation interface is provided in the docstring at the top of the source files for each relation.
 
@@ -25,14 +25,6 @@ These relations will be deprecated in future. When deploying these relations, pl
 
 - `db:`[`pgsql`](https://github.com/canonical/ops-lib-pgsql/)
 - `db-admin:`[`pgsql`](https://github.com/canonical/ops-lib-pgsql/)
-
-### Planned
-
-The following relations provide support for the [LMA charm bundle](https://juju.is/docs/lma2), our expected observability stack.
-
-- `prometheus:prometheus_scrape`
-- `loki:loki_push_api`
-- `grafana:grafana_dashboards`
 
 ## OCI Images
 


### PR DESCRIPTION
## Issue
Closes https://github.com/canonical/pgbouncer-k8s-operator/issues/148

## Solution
Update the readme to reference the correct endpoint