### PR TITLE
[MISC] Copy 3.1.7 fix from Mongo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
         juju:
           - agent: 2.9.46
             libjuju: ^2
-          - agent: 3.1.6
+          - agent: 3.1.7
     name: Integration test charm | ${{ matrix.juju.agent }}
     needs:
       - lint


### PR DESCRIPTION
Copy Juju 3.1.7 fix from the mongo charm, so that we can deploy without downgrading the agent.