### PR TITLE
Added status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# PgBouncer Kubernetes Operator
+# Charmed PgBouncer Kubernetes Operator
+[![Charmhub](https://charmhub.io/pgbouncer-k8s/badge.svg)](https://charmhub.io/pgbouncer-k8s)
+[![Release](https://github.com/canonical/pgbouncer-k8s-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/pgbouncer-k8s-operator/actions/workflows/release.yaml)
+[![Tests](https://github.com/canonical/pgbouncer-k8s-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/pgbouncer-k8s-operator/actions/workflows/ci.yaml)
 
 ## Description
 


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added workflow badges for 
* CharmHub
* Release
* Tests