### PR TITLE
Fix deletion test

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -348,7 +348,6 @@ class PgBouncerK8sCharm(CharmBase):
         self.unit.set_workload_version(self.version)
 
         self.peers.unit_databag["container_initialised"] = "True"
-        self.patch_port()
 
     @property
     def is_container_ready(self) -> bool:

--- a/tests/integration/relations/pgbouncer_provider/helpers.py
+++ b/tests/integration/relations/pgbouncer_provider/helpers.py
@@ -125,6 +125,24 @@ async def run_sql_on_application_charm(
     return result.results
 
 
+async def is_external_connectivity_set(
+    ops_test: OpsTest,
+    application_name: str,
+    relation_name: str,
+    relation_id: str = None,
+) -> Optional[str]:
+    data = await get_application_relation_data(
+        ops_test,
+        application_name,
+        relation_name,
+        "data",
+        relation_id,
+    )
+    if not data:
+        return False
+    return json.loads(data).get("external-node-connectivity", None) == "true"
+
+
 async def build_connection_string(
     ops_test: OpsTest,
     application_name: str,
@@ -178,14 +196,24 @@ async def build_connection_string(
     )
     host = endpoints.split(",")[0].split(":")[0]
 
-    # Translate the pod hostname to an IP address.
-    model = ops_test.model.info
-    client = AsyncClient(namespace=model.name)
-    pod = await client.get(Pod, name=host.split(".")[0])
-    ip = pod.status.podIP
+    use_node_port = await is_external_connectivity_set(
+        ops_test,
+        application_name,
+        relation_name,
+        relation_id,
+    )
+
+    if use_node_port:
+        return f"dbname='{database}' user='{username}' host='{host}' port={endpoints.split(',')[0].split(':')[1]} password='{password}' connect_timeout=10"
+    else:
+        # Translate the pod hostname to an IP address.
+        model = ops_test.model.info
+        client = AsyncClient(namespace=model.name)
+        pod = await client.get(Pod, name=host.split(".")[0])
+        ip = pod.status.podIP
 
     # Build the complete connection string to connect to the database.
-    return f"dbname='{database}' user='{username}' host='{ip}' password='{password}' connect_timeout=10"
+    return f"dbname='{database}' user='{username}' host='{ip}' password='{password}' connect_timeout=10 port=6432"
 
 
 async def check_new_relation(

--- a/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
+++ b/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
@@ -498,8 +498,8 @@ async def test_indico_datatabase(ops_test: OpsTest) -> None:
             application_name="indico",
             num_units=1,
         )
-        await ops_test.model.deploy("redis-k8s", channel="stable", application_name="redis-broker")
-        await ops_test.model.deploy("redis-k8s", channel="stable", application_name="redis-cache")
+        await ops_test.model.deploy("redis-k8s", channel="latest/edge", application_name="redis-broker")
+        await ops_test.model.deploy("redis-k8s", channel="latest/edge", application_name="redis-cache")
         await asyncio.gather(
             ops_test.model.relate("redis-broker", "indico:redis-broker"),
             ops_test.model.relate("redis-cache", "indico:redis-cache"),
@@ -532,6 +532,8 @@ async def test_connection_is_possible_after_pod_deletion(ops_test: OpsTest) -> N
     unit = ops_test.model.applications[PGB].units[0]
     await delete_pod(ops_test, unit.name)
     await ops_test.model.wait_for_idle(status="active", idle_period=3)
+
+    await asyncio.sleep(20)
 
     # Test the connection.
     connection_string = await build_connection_string(

--- a/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
+++ b/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
@@ -537,7 +537,6 @@ async def test_connection_is_possible_after_pod_deletion(ops_test: OpsTest) -> N
     connection_string = await build_connection_string(
         ops_test, DATA_INTEGRATOR_APP_NAME, relation_name="postgresql", database="test-database"
     )
-    connection_string += " port=6432"
     connection = None
     try:
         connection = psycopg2.connect(connection_string)

--- a/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
+++ b/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
@@ -498,8 +498,12 @@ async def test_indico_datatabase(ops_test: OpsTest) -> None:
             application_name="indico",
             num_units=1,
         )
-        await ops_test.model.deploy("redis-k8s", channel="latest/edge", application_name="redis-broker")
-        await ops_test.model.deploy("redis-k8s", channel="latest/edge", application_name="redis-cache")
+        await ops_test.model.deploy(
+            "redis-k8s", channel="latest/stable", application_name="redis-broker"
+        )
+        await ops_test.model.deploy(
+            "redis-k8s", channel="latest/stable", application_name="redis-cache"
+        )
         await asyncio.gather(
             ops_test.model.relate("redis-broker", "indico:redis-broker"),
             ops_test.model.relate("redis-cache", "indico:redis-cache"),

--- a/tests/unit/relations/test_pgbouncer_provider.py
+++ b/tests/unit/relations/test_pgbouncer_provider.py
@@ -34,6 +34,7 @@ class TestPgbouncerProvider(unittest.TestCase):
         self.client_rel_id = self.harness.add_relation(CLIENT_RELATION_NAME, "application")
         self.harness.add_relation_unit(self.client_rel_id, "application/0")
 
+    @patch("charm.lightkube")
     @patch("relations.backend_database.BackendDatabaseRequires.check_backend", return_value=True)
     @patch(
         "relations.backend_database.BackendDatabaseRequires.postgres", new_callable=PropertyMock
@@ -78,6 +79,7 @@ class TestPgbouncerProvider(unittest.TestCase):
         _pg_databag,
         _pg,
         _check_backend,
+        _,
     ):
         self.harness.set_leader()
         _gen_rel_dbs.return_value = {}


### PR DESCRIPTION
Removes the need for `patch_port()` at `pebble-ready` event. There is no reason to check if we need to patch the port at this event, as port should be toggled to ClusterIP / NodePort in response to client relations exclusively. Also, pebble-ready happens at every restart of the pod, which per-se does not mark as a change on exposing or not the service.

Simplifying the `external_connectivity()` to make it more readable and adding extra safeguards in the relation checking methods for node-port.

Fixes the tests to consider NodePort *or* ClusterIP accordingly.