### PR TITLE
[MISC] Don't autostart metrics service if password is not yet set

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -490,8 +490,7 @@ class PgBouncerK8sCharm(CharmBase):
         self.check_pgb_running()
 
     def _generate_monitoring_service(self, enabled: bool = True) -> Dict[str, str]:
-        if enabled:
-            stats_password = self.get_secret(APP_SCOPE, MONITORING_PASSWORD_KEY)
+        if enabled and (stats_password := self.get_secret(APP_SCOPE, MONITORING_PASSWORD_KEY)):
             command = (
                 f'pgbouncer_exporter --web.listen-address=:{METRICS_PORT} --pgBouncer.connectionString="'
                 f'postgres://{self.backend.stats_user}:{stats_password}@localhost:{self.config["listen_port"]}/pgbouncer?sslmode=disable"'


### PR DESCRIPTION
Tested on https://github.com/canonical/data-integrator/pull/49

Looks like the issue was indeed the metrics service.