### PR TITLE
[DPE-3991] Update old information on CONTRIBUTING and LICENSE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,7 @@ This documents explains the processes and practices recommended for contributing
 - Generally, before developing enhancements to this charm, you should consider [opening an issue
   ](https://github.com/canonical/pgbouncer-k8s-operator/issues) explaining your use case.
 - If you would like to chat with us about your use-cases or proposed implementation, you can reach
-  us at [Canonical Mattermost public channel](https://chat.charmhub.io/charmhub/channels/charm-dev)
-  or [Discourse](https://discourse.charmhub.io/).
+  us using any channel from our [Contacts](https://charmhub.io/pgbouncer-k8s/docs/r-contacts).
 - Familiarising yourself with the [Charmed Operator Framework](https://juju.is/docs/sdk) library
   will help you a lot when working on new features or bug fixes.
 - All enhancements require at least 2 approving reviews before being merged. Code review typically examines

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Canonical Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Issue

Addressing reviewer comments from #283 as part of preparation for making pgbouncer-k8s charm listed on charmhub.io

## Solution

Update with new information the contact link at CONTRIBUTING and fix LICENSE Copyright notice with Canonical Ltd as owner.