### PR TITLE
Pin sync_docs.yaml version

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@main
+    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@19.0.0
     secrets:
       discourse-api-user: ${{ secrets.DISCOURSE_API_USERNAME }}
       discourse-api-key: ${{ secrets.DISCOURSE_API_KEY }}


### PR DESCRIPTION
Pins `_sync_docs.yaml` to a release instead of `main`. This prevents the workflow from breaking when a new sync_docs is released to the public interface.

