### PR TITLE
Update sync_docs.yaml to new version

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@20.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v20.0.0
     secrets:
       discourse-api-user: ${{ secrets.DISCOURSE_API_USERNAME }}
       discourse-api-key: ${{ secrets.DISCOURSE_API_KEY }}

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@20.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@20.0.0
     secrets:
       discourse-api-user: ${{ secrets.DISCOURSE_API_USERNAME }}
       discourse-api-key: ${{ secrets.DISCOURSE_API_KEY }}


### PR DESCRIPTION
A [new `sync_docs.yaml` workflow](https://github.com/canonical/data-platform-workflows/pull/220) was released in data-platform-workflows `v19.2.0`. It overwrites the old experimental `_sync_docs.yaml` workflow and releases it to the public interface.

This PR corrects the filename to match the new syntax without the experimental `_` prefix.