### PR TITLE
[MISC] Ignore sync docs changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ on:
       - 'LICENSE'
       - '**.md'
       - .github/renovate.json5
+      - '.github/workflows/sync_docs.yaml'
   schedule:
     - cron: '53 0 * * *' # Daily at 00:53 UTC
   # Triggered on push to branch "main" by .github/workflows/release.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ on:
       - pyproject.toml
       - '.github/workflows/ci.yaml'
       - '.github/workflows/lib-check.yaml'
+      - '.github/workflows/sync_docs.yaml'
 
 jobs:
   ci-tests:


### PR DESCRIPTION
Sync docs run on schedule, so there is no point in triggering CI/release flows when they change.