### PR TITLE
[MISC] Don't set secrets until db is set

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 39
+LIBPATCH = 40
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -389,6 +389,10 @@ class SecretsIllegalUpdateError(SecretError):
 
 class IllegalOperationError(DataInterfacesError):
     """To be used when an operation is not allowed to be performed."""
+
+
+class PrematureDataAccessError(DataInterfacesError):
+    """To be raised when the Relation Data may be accessed (written) before protocol init complete."""
 
 
 ##############################################################################
@@ -1453,6 +1457,8 @@ class EventHandlers(Object):
 class ProviderData(Data):
     """Base provides-side of the data products relation."""
 
+    RESOURCE_FIELD = "database"
+
     def __init__(
         self,
         model: Model,
@@ -1618,6 +1624,15 @@ class ProviderData(Data):
     def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Set values for fields not caring whether it's a secret or not."""
         req_secret_fields = []
+
+        keys = set(data.keys())
+        if self.fetch_relation_field(relation.id, self.RESOURCE_FIELD) is None and (
+            keys - {"endpoints", "read-only-endpoints", "replset"}
+        ):
+            raise PrematureDataAccessError(
+                "Premature access to relation data, update is forbidden before the connection is initialized."
+            )
+
         if relation.app:
             req_secret_fields = get_encoded_list(relation, relation.app, REQ_SECRET_FIELDS)
 
@@ -3290,6 +3305,8 @@ class KafkaRequiresEvents(CharmEvents):
 class KafkaProviderData(ProviderData):
     """Provider-side of the Kafka relation."""
 
+    RESOURCE_FIELD = "topic"
+
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)
 
@@ -3538,6 +3555,8 @@ class OpenSearchRequiresEvents(CharmEvents):
 
 class OpenSearchProvidesData(ProviderData):
     """Provider-side of the OpenSearch relation."""
+
+    RESOURCE_FIELD = "index"
 
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,10 +23,9 @@ from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.tempo_k8s.v1.charm_tracing import trace_charm
 from charms.tempo_k8s.v2.tracing import TracingEndpointRequirer
 from jinja2 import Template
-from ops import JujuVersion
+from ops import JujuVersion, main
 from ops.charm import CharmBase, ConfigChangedEvent, PebbleReadyEvent
 from ops.framework import StoredState
-from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Relation, WaitingStatus
 from ops.pebble import ConnectionError, Layer, ServiceStatus
 

--- a/src/relations/pgbouncer_provider.py
+++ b/src/relations/pgbouncer_provider.py
@@ -228,7 +228,10 @@ class PgBouncerProvider(Object):
         self.update_endpoints(relation)
 
         # Set the database version.
-        if self.charm.backend.check_backend():
+        if (
+            self.database_provides.fetch_relation_field(relation.id, "database")
+            and self.charm.backend.check_backend()
+        ):
             self.database_provides.set_version(
                 relation.id, self.charm.backend.postgres.get_postgresql_version(current_host=False)
             )
@@ -253,6 +256,9 @@ class PgBouncerProvider(Object):
             user = f"relation_id_{relation.id}"
             database = self.database_provides.fetch_relation_field(relation.id, "database")
             password = self.database_provides.fetch_my_relation_field(relation.id, "password")
+            if not database or not password:
+                return
+
             # Read-write endpoint
             if relation.data[relation.app].get("external-node-connectivity", "false") == "true":
                 self.database_provides.set_endpoints(relation.id, nodeports["rw"])

--- a/tests/unit/relations/test_pgbouncer_provider.py
+++ b/tests/unit/relations/test_pgbouncer_provider.py
@@ -62,6 +62,10 @@ class TestPgbouncerProvider(unittest.TestCase):
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseProvides.set_credentials")
     @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseProvides.set_version")
     @patch(
+        "charms.data_platform_libs.v0.data_interfaces.DatabaseProvides.fetch_my_relation_field",
+        return_value="test_pass",
+    )
+    @patch(
         "charm.PgBouncerK8sCharm.get_node_ports",
         return_value={
             "rw": "rw:5432",
@@ -75,6 +79,7 @@ class TestPgbouncerProvider(unittest.TestCase):
         _gen_rel_dbs,
         _set_rel_dbs,
         _get_node_ports,
+        _dbp_fetch_my_relation_field,
         _dbp_set_version,
         _dbp_set_credentials,
         _get_database,
@@ -93,10 +98,12 @@ class TestPgbouncerProvider(unittest.TestCase):
         _gen_rel_dbs.return_value = {}
 
         event = MagicMock()
-        rel_id = event.relation.id = 1
+        rel_id = event.relation.id = self.client_rel_id
         database = event.database = "test-db"
         event.extra_user_roles = "SUPERUSER"
         user = f"relation_id_{rel_id}"
+        with self.harness.hooks_disabled():
+            self.harness.update_relation_data(rel_id, "application", {"database": "test-db"})
 
         # check we exit immediately if backend doesn't exist.
         _check_backend.return_value = False
@@ -120,7 +127,7 @@ class TestPgbouncerProvider(unittest.TestCase):
         )
         _set_read_only_endpoints.assert_called()
         _set_rel_dbs.assert_called_once_with({
-            "1": {"name": "test-db", "legacy": False},
+            str(rel_id): {"name": "test-db", "legacy": False},
             "*": {"name": "*", "auth_dbname": "test-db"},
         })
         _render_pgb_config.assert_called_once_with(reload_pgbouncer=True)


### PR DESCRIPTION
Port of https://github.com/canonical/pgbouncer-operator/pull/373

* Update libs
* Removes an OPS import warning
* Fixes wrong emission of `database_created` due to creating the secret before the requirer sets the requested database (data-integrator) 