### PR TITLE
[MISC] Disable linting for docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
     poetry run codespell {tox_root} --skip {tox_root}/.git --skip {tox_root}/.tox \
       --skip {tox_root}/build --skip {tox_root}/lib --skip {tox_root}/venv \
       --skip {tox_root}/.mypy_cache --skip {tox_root}/LICENSE --skip {tox_root}/poetry.lock \
-      --skip {[vars]test_charm_libs}
+      --skip {[vars]test_charm_libs} --skip {tox_root}/docs
     poetry run codespell {[vars]lib_path}
     # pflake8 wrapper supports config from pyproject.toml
     poetry run ruff check {[vars]all_path}


### PR DESCRIPTION
Disable codespell for docs, since typos there will break the build and we should update those in discourse rather than fix in repo