### PR TITLE
[DPE-5622] Fix test_tls.py test by installing 1 mattermost unit only

### DIFF
--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -162,6 +162,6 @@ async def test_mattermost_db(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         # Deploy Mattermost
         await deploy_and_relate_application_with_pgbouncer(
-            ops_test, MATTERMOST_APP_NAME, MATTERMOST_APP_NAME, APPLICATION_UNITS, status="waiting"
+            ops_test, MATTERMOST_APP_NAME, MATTERMOST_APP_NAME, 1, status="waiting"
         )
         await ops_test.model.remove_application(MATTERMOST_APP_NAME, block_until_done=True)


### PR DESCRIPTION
## Issue
The Mattermost randomly crashed in PGB TLS CI test, reported upstream as
https://github.com/canonical/mattermost-k8s-operator/issues/30

## Solution
The Mattermost enterprise license is required to install/use Mattermost clustering:
> https://charmhub.io/mattermost-k8s/docs/scale-and-monitor-performance

Switch test to install mattermost-k8s in the single unit only.
