### PR TITLE
[DPE-6042] Make tox commands resilient to white-space paths

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,15 +7,15 @@ skip_missing_interpreters = True
 env_list = lint, unit
 
 [vars]
-src_path = {tox_root}/src
-tests_path = {tox_root}/tests
-lib_path = {tox_root}/lib/charms/pgbouncer_k8s
-test_charm_libs = {tox_root}/tests/integration/relations/pgbouncer_provider/application-charm/lib
+src_path = "{tox_root}/src"
+tests_path = "{tox_root}/tests"
+lib_path = "{tox_root}/lib/charms/pgbouncer_k8s"
+test_charm_libs = "{tox_root}/tests/integration/relations/pgbouncer_provider/application-charm/lib"
 all_path = {[vars]src_path} {[vars]tests_path} {[vars]lib_path}
 
 [testenv]
 set_env =
-    PYTHONPATH = {tox_root}/lib:{[vars]src_path}
+    PYTHONPATH = {tox_root}/lib:{tox_root}/src
     PYTHONBREAKPOINT=ipdb.set_trace
     PY_COLORS=1
 pass_env =
@@ -40,10 +40,10 @@ commands_pre =
     poetry install --only lint,format --no-root
 commands =
     poetry check --lock
-    poetry run codespell {tox_root} --skip {tox_root}/.git --skip {tox_root}/.tox \
-      --skip {tox_root}/build --skip {tox_root}/lib --skip {tox_root}/venv \
-      --skip {tox_root}/.mypy_cache --skip {tox_root}/LICENSE --skip {tox_root}/poetry.lock \
-      --skip {[vars]test_charm_libs} --skip {tox_root}/docs
+    poetry run codespell "{tox_root}" --skip "{tox_root}/.git" --skip "{tox_root}/.tox" \
+      --skip "{tox_root}/build" --skip "{tox_root}/lib" --skip "{tox_root}/venv" \
+      --skip "{tox_root}/.mypy_cache" --skip "{tox_root}/LICENSE" --skip "{tox_root}/poetry.lock" \
+      --skip {[vars]test_charm_libs} --skip "{tox_root}/docs"
     poetry run codespell {[vars]lib_path}
     # pflake8 wrapper supports config from pyproject.toml
     poetry run ruff check {[vars]all_path}

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ env_list = lint, unit
 src_path = "{tox_root}/src"
 tests_path = "{tox_root}/tests"
 lib_path = "{tox_root}/lib/charms/pgbouncer_k8s"
-test_charm_libs = "{tox_root}/tests/integration/relations/pgbouncer_provider/application-charm/lib"
 all_path = {[vars]src_path} {[vars]tests_path} {[vars]lib_path}
 
 [testenv]
@@ -43,7 +42,7 @@ commands =
     poetry run codespell "{tox_root}" --skip "{tox_root}/.git" --skip "{tox_root}/.tox" \
       --skip "{tox_root}/build" --skip "{tox_root}/lib" --skip "{tox_root}/venv" \
       --skip "{tox_root}/.mypy_cache" --skip "{tox_root}/LICENSE" --skip "{tox_root}/poetry.lock" \
-      --skip {[vars]test_charm_libs} --skip "{tox_root}/docs"
+      --skip "{tox_root}/docs"
     poetry run codespell {[vars]lib_path}
     # pflake8 wrapper supports config from pyproject.toml
     poetry run ruff check {[vars]all_path}


### PR DESCRIPTION
This PR fixes [tox.ini](https://github.com/canonical/pgbouncer-k8s-operator/blob/main/tox.ini) commands when the repository is cloned on a white-space containing path.

### How to reproduce:
```shell
$ mkdir -p "Projects/Canonical/Data Platform/PostgreSQL"
$ cd "Projects/Canonical/Data Platform/PostgreSQL"
$ git clone https://github.com/canonical/pgbouncer-k8s-operator
$ cd pgbouncer-k8s-operator
$ tox run -e format
> ...
> /Users/<USERNAME>/Projects/Canonical/Data:1:1: E902 No such file or directory (os error 2)
> Platform/PostgreSQL/pgbouncer-k8s-operator/src:1:1: E902 No such file or directory (os error 2)
> Platform/PostgreSQL/pgbouncer-k8s-operator/tests:1:1: E902 No such file or directory (os error 2)

```

### Additional considerations
Using the quoted paths to set up the `PYTHONPATH` does not work. This can be tested by running the unit tests.