### PR TITLE
Fix minor typo in access of ServiceSpec object

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -596,7 +596,7 @@ class PgBouncerK8sCharm(TypedCharmBase):
             return False
 
         endpoints_to_connect = [self.read_write_endpoints]
-        if self.read_only_endpoints or service.spec.name != ServiceType("false").name:
+        if self.read_only_endpoints or service.spec.type != ServiceType("false").name:
             endpoints_to_connect.append(self.read_only_endpoints)
 
         for endpoints in endpoints_to_connect:

--- a/tests/integration/test_expose_external.py
+++ b/tests/integration/test_expose_external.py
@@ -165,7 +165,9 @@ async def test_expose_external(ops_test) -> None:
 
         load_balancer_endpoints = await confirm_endpoint_connectivity(ops_test)
 
-        assert nodeport_endpoints != load_balancer_endpoints, "Endpoints did not change for expose-external=loadbalancer"
+        assert nodeport_endpoints != load_balancer_endpoints, (
+            "Endpoints did not change for expose-external=loadbalancer"
+        )
 
 
 @pytest.mark.group(1)
@@ -224,4 +226,6 @@ async def test_expose_external_with_tls(ops_test: OpsTest) -> None:
 
         load_balancer_endpoints = await confirm_endpoint_connectivity(ops_test)
 
-        assert nodeport_endpoints != load_balancer_endpoints, "Endpoints did not change for expose-external=loadbalancer"
+        assert nodeport_endpoints != load_balancer_endpoints, (
+            "Endpoints did not change for expose-external=loadbalancer"
+        )


### PR DESCRIPTION
## Issue
[ServiceSpec](https://gtsystem.github.io/lightkube-models/1.32/models/core_v1/#servicespec) does not have a property `name`

## Solution
Fix access to `service.spec.type`
Also, ensure nodeport_endpoints are different than load_balancer_endpoints in test_expose_external.py