### PR TITLE
[MISC] Limit solver to 1d old dependencies

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,3 @@
+[solver]
+min-release-age = 1
+min-release-age-exclude = "postgresql-charms-single-kernel"


### PR DESCRIPTION
Follow up to https://github.com/canonical/data-platform/pull/42.

Add minimum age for Poetry lock