### PR TITLE
[DPE-9936] Conditionally add discard directives

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1075,6 +1075,7 @@ class PgBouncerK8sCharm(TypedCharmBase):
                         key_file=f"{PGB_DIR}/{TLS_KEY_FILE}",
                         ca_file=f"{PGB_DIR}/{TLS_CA_FILE}",
                         cert_file=f"{PGB_DIR}/{TLS_CERT_FILE}",
+                        backend_version=self.backend.backend_major_version,
                     ),
                     perm,
                 )

--- a/src/relations/backend_database.py
+++ b/src/relations/backend_database.py
@@ -155,7 +155,7 @@ class BackendDatabaseRequires(Object):
             database=database,
         )
 
-    @property
+    @cached_property
     def backend_version(self) -> str:
         """Backend Oostgresql version."""
         if not self.relation:
@@ -164,6 +164,17 @@ class BackendDatabaseRequires(Object):
         if version := self.database.fetch_relation_field(self.relation.id, "version"):
             return version
         return ""
+
+    @cached_property
+    def backend_major_version(self) -> int:
+        """Backend Postgresql version."""
+        if not self.relation or self.backend_version:
+            return 0
+
+        try:
+            return int(self.backend_version.split(".")[0])
+        except ValueError:
+            return 0
 
     @property
     def auth_user(self) -> str | None:

--- a/templates/pgb_config.j2
+++ b/templates/pgb_config.j2
@@ -40,5 +40,6 @@ client_tls_ca_file = {{ ca_file }}
 client_tls_cert_file = {{ cert_file }}
 client_tls_sslmode = prefer
 {% endif %}
-server_reset_query = DISCARD ALL; LOAD 'login_hook';
-server_reset_query_always = 1
+{% if backend_version > 16 -%}
+server_reset_query = CLOSE ALL; RESET ALL; DEALLOCATE ALL; UNLISTEN *; SELECT pg_advisory_unlock_all(); DISCARD PLANS; DISCARD TEMP; DISCARD SEQUENCES;
+{% endif %}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -243,6 +243,7 @@ class TestCharm(unittest.TestCase):
                 auth_query="SELECT username, password FROM pgbouncer_auth_BACKNEND_USER.get_auth($1)",
                 auth_file="/dev/shm/pgbouncer-k8s_test",
                 enable_tls=False,
+                backend_version=16,
             )
             _push_file.assert_any_call(
                 f"/var/lib/pgbouncer/instance_{i}/pgbouncer.ini", expected_content, 0o400
@@ -295,6 +296,7 @@ class TestCharm(unittest.TestCase):
                 auth_query="SELECT username, password FROM pgbouncer_auth_BACKNEND_USER.get_auth($1)",
                 auth_file="/dev/shm/pgbouncer-k8s_test",
                 enable_tls=False,
+                backend_version=16,
             )
             _push_file.assert_any_call(
                 f"/var/lib/pgbouncer/instance_{i}/pgbouncer.ini", expected_content, 0o400


### PR DESCRIPTION
Relates to https://github.com/canonical/pgbouncer-k8s-operator/issues/740
Port of https://github.com/canonical/pgbouncer-operator/pull/711

## Issue
When adapting the charm to Postgresql 16 charm roles management, we added a workaround for recycled connections, so that the `charmed_{dbname}_owner` role is not lost. The workaround generates excessive error logs in the Postgresql charm and does not properly recycle the relation.

## Solution
The workaround is not necessary for Postgresql 14 charm, since roles work differently and for Postgresql 16 charm it should match the discard command without resetting the role.
