### PR TITLE
fix(config): preserve charmed role by setting server_reset_query on PostgreSQL 16+

### DIFF
--- a/src/relations/backend_database.py
+++ b/src/relations/backend_database.py
@@ -165,10 +165,10 @@ class BackendDatabaseRequires(Object):
             return version
         return ""
 
-    @cached_property
+    @property
     def backend_major_version(self) -> int:
         """Backend Postgresql version."""
-        if not self.relation or self.backend_version:
+        if not self.relation or not self.backend_version:
             return 0
 
         try:

--- a/templates/pgb_config.j2
+++ b/templates/pgb_config.j2
@@ -40,6 +40,7 @@ client_tls_ca_file = {{ ca_file }}
 client_tls_cert_file = {{ cert_file }}
 client_tls_sslmode = prefer
 {% endif %}
-{% if backend_version > 16 -%}
+{% if backend_version >= 16 -%}
 server_reset_query = CLOSE ALL; RESET ALL; DEALLOCATE ALL; UNLISTEN *; SELECT pg_advisory_unlock_all(); DISCARD PLANS; DISCARD TEMP; DISCARD SEQUENCES;
 {% endif %}
+

--- a/tests/unit/relations/test_backend_database.py
+++ b/tests/unit/relations/test_backend_database.py
@@ -235,3 +235,22 @@ class TestBackendDatabaseRelation(unittest.TestCase):
         _ready.return_value = False
         assert not self.charm.backend.check_backend()
         assert isinstance(self.charm.unit.status, WaitingStatus)
+
+    def test_backend_major_version(self):
+        with patch.object(
+            type(self.backend), "relation", new_callable=PropertyMock
+        ) as mock_relation:
+            mock_relation.return_value = None
+            assert self.backend.backend_major_version == 0
+
+        with patch.object(
+            type(self.backend), "backend_version", new_callable=PropertyMock
+        ) as mock_version:
+            mock_version.return_value = ""
+            assert self.backend.backend_major_version == 0
+
+            mock_version.return_value = "14.16"
+            assert self.backend.backend_major_version == 14
+
+            mock_version.return_value = "16.14"
+            assert self.backend.backend_major_version == 16

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -144,7 +144,7 @@ class TestCharm(unittest.TestCase):
     )
     @patch(
         "relations.backend_database.DatabaseRequires.fetch_relation_field",
-        return_value="BACKNEND_USER",
+        side_effect=lambda relation_id, field: "16.14" if field == "version" else "BACKNEND_USER",
     )
     @patch(
         "charm.BackendDatabaseRequires.relation", new_callable=PropertyMock, return_value=Mock()
@@ -248,6 +248,11 @@ class TestCharm(unittest.TestCase):
             _push_file.assert_any_call(
                 f"/var/lib/pgbouncer/instance_{i}/pgbouncer.ini", expected_content, 0o400
             )
+            assert (
+                "server_reset_query = CLOSE ALL; RESET ALL; DEALLOCATE ALL; UNLISTEN *; SELECT pg_advisory_unlock_all(); DISCARD PLANS; DISCARD TEMP; DISCARD SEQUENCES;"
+                in expected_content
+            )
+
         _check_pgb_running.assert_called_once_with()
         _send_signal.assert_has_calls([
             call(SIGHUP, service["name"]) for service in self.charm._services


### PR DESCRIPTION
## Issue

On PostgreSQL 16+ (Ubuntu 24.04 Noble), default client connection recycling uses PgBouncer's built-in \`DISCARD ALL\`, which resets session authorization and drops privileges back to the relation user. Consequently, subsequent operations in the \`public\` schema fail with \`InsufficientPrivilege: permission denied for schema public\` due to PostgreSQL 15+ revoking public schema \`CREATE\` privileges from \`PUBLIC\`.

The intended custom \`server_reset_query\` was omitted due to an inverted boolean check in \`backend_major_version\` and a strict inequality \`> 16\` in the configuration template.

## Solution

Fix \`backend_major_version\` condition to check \`if not self.relation or not self.backend_version:\`, and update \`templates/pgb_config.j2\` to \`{% if backend_version >= 16 -%}\` so that the tailored reset query is emitted for PostgreSQL 16+.

Tested on https://github.com/canonical/postgresql-test-app/pull/543.