### PR TITLE
[DPE-11007] Follow juju CPU constraints when sizing pgbouncer instances

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -44,8 +44,8 @@ options:
       which are documented in the pgbouncer config docs here:
       https://www.pgbouncer.org/config.html.
 
-      - Firstly, the number of pgbouncer instances is calculated based on the
-        number of CPU cores in the current deployment.
+      - Firstly, the number of pgbouncer instances is calculated from the CPU
+        provisioned for the pgbouncer container, clamped to between 2 and 4.
       - effective DB connections = max_db_connections / pgbouncer instances
       - default_pool_size = effective connections / 2
       - min_pool_size = effective connections / 4

--- a/src/charm.py
+++ b/src/charm.py
@@ -55,7 +55,9 @@ from constants import (
     CONTAINER_UNAVAILABLE_MESSAGE,
     EXTENSIONS_BLOCKING_MESSAGE,
     K8S_SERVICE_CONNECT_TIMEOUT,
+    MAX_INSTANCES,
     METRICS_PORT,
+    MIN_INSTANCES,
     MONITORING_PASSWORD_KEY,
     PEER_RELATION_NAME,
     PG_GROUP,
@@ -201,26 +203,19 @@ class PgBouncerK8sCharm(TypedCharmBase):
         """Number of pgbouncer processes to run on this unit.
 
         PgBouncer is single-threaded, so one process is run per CPU that Kubernetes has
-        provisioned for the pgbouncer container. Sources are tried in order:
+        provisioned for the pgbouncer container, read from the cgroup quota enforced inside
+        it. When no quota is enforced the host CPU count is used instead. The result is
+        rounded up and clamped to between MIN_INSTANCES and MAX_INSTANCES.
 
-        1. the CPU limit, or failing that the CPU request, on the pgbouncer container;
-        2. the cgroup quota enforced inside the container, when the pod spec is unreadable;
-        3. the host CPU count, when neither of the above provisions a limit.
-
-        The result is rounded up and clamped to between MIN_INSTANCES and MAX_INSTANCES.
+        Deliberately avoids the Kubernetes API: this runs on every hook, and a blocking
+        call to the API server here delays or kills hooks when it is slow or unreachable.
         """
-        try:
-            pod = get_pod(self.unit.name, self.model.name)
-            cores = cpu.container_cpu_limit(pod, PGB)
-        except Exception as e:
-            logger.warning("Unable to read the pod spec (%s), reading the cgroup quota instead", e)
-            cores = cpu.cgroup_cpu_limit(self.unit.get_container(PGB))
-
+        cores = cpu.cgroup_cpu_limit(self.unit.get_container(PGB))
         if cores is None:
-            logger.info("No CPU limit provisioned for %s, using the host CPU count", PGB)
-            cores = os.cpu_count() or cpu.MIN_INSTANCES
+            logger.info("No CPU quota readable for %s, using the host CPU count", PGB)
+            cores = os.cpu_count() or MIN_INSTANCES
 
-        return max(min(math.ceil(cores), cpu.MAX_INSTANCES), cpu.MIN_INSTANCES)
+        return max(min(math.ceil(cores), MAX_INSTANCES), MIN_INSTANCES)
 
     def get_service(self) -> lightkube.resources.core_v1.Service | None:
         """Get the managed k8s service."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -45,6 +45,7 @@ from single_kernel_postgresql.compat.postgresql import (
     INVALID_EXTRA_USER_ROLE_BLOCKING_MESSAGE,
 )
 
+import cpu
 from config import CharmConfig, ServiceType
 from constants import (
     APP_SCOPE,
@@ -159,7 +160,7 @@ class PgBouncerK8sCharm(TypedCharmBase):
             ],
         )
 
-        self._cores = max(min(os.cpu_count(), 4), 2)
+        self._cores = self._instance_count()
         self._services = [
             {
                 "name": f"{PGB}_{service_id}",
@@ -195,6 +196,31 @@ class PgBouncerK8sCharm(TypedCharmBase):
         self.INSUFFICIENT_PERMISSIONS_MESSAGE = (
             f"Insufficient permissions, try: `juju trust {self.app.name} --scope=cluster`"
         )
+
+    def _instance_count(self) -> int:
+        """Number of pgbouncer processes to run on this unit.
+
+        PgBouncer is single-threaded, so one process is run per CPU that Kubernetes has
+        provisioned for the pgbouncer container. Sources are tried in order:
+
+        1. the CPU limit, or failing that the CPU request, on the pgbouncer container;
+        2. the cgroup quota enforced inside the container, when the pod spec is unreadable;
+        3. the host CPU count, when neither of the above provisions a limit.
+
+        The result is rounded up and clamped to between MIN_INSTANCES and MAX_INSTANCES.
+        """
+        try:
+            pod = get_pod(self.unit.name, self.model.name)
+            cores = cpu.container_cpu_limit(pod, PGB)
+        except Exception as e:
+            logger.warning("Unable to read the pod spec (%s), reading the cgroup quota instead", e)
+            cores = cpu.cgroup_cpu_limit(self.unit.get_container(PGB))
+
+        if cores is None:
+            logger.info("No CPU limit provisioned for %s, using the host CPU count", PGB)
+            cores = os.cpu_count() or cpu.MIN_INSTANCES
+
+        return max(min(math.ceil(cores), cpu.MAX_INSTANCES), cpu.MIN_INSTANCES)
 
     def get_service(self) -> lightkube.resources.core_v1.Service | None:
         """Get the managed k8s service."""

--- a/src/constants.py
+++ b/src/constants.py
@@ -7,6 +7,10 @@
 from typing import Literal
 
 PGB = "pgbouncer"
+
+# PgBouncer is single-threaded: one process per provisioned CPU, within these bounds
+MIN_INSTANCES = 2
+MAX_INSTANCES = 4
 PG = PG_USER = PG_GROUP = "postgres"
 
 PGB_DIR = "/var/lib/pgbouncer"

--- a/src/cpu.py
+++ b/src/cpu.py
@@ -1,12 +1,12 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Detection of the CPU allocation provisioned for the pgbouncer container.
+"""Detection of the CPU quota Kubernetes enforces on the pgbouncer container.
 
-PgBouncer is single-threaded, so the charm runs one process per provisioned CPU. The
-helpers here read a single source each; `PgBouncerK8sCharm._instance_count` is where they
-are tried in order. Note that `os.cpu_count()`, the last resort there, reports the CPUs of
-the whole node, ignoring both cgroup quotas and affinity.
+Juju turns a `cores`/`cpu-power` constraint into a CPU *limit* on the workload container,
+which the kernel enforces as a cgroup quota. Reading that quota from inside the container
+needs no Kubernetes API call and no `juju trust`. The charm container has no CPU limit of
+its own, so `os.cpu_count()` there reports the whole node.
 """
 
 import logging
@@ -19,37 +19,6 @@ logger = logging.getLogger(__name__)
 CGROUP_V2_CPU_MAX = "/sys/fs/cgroup/cpu.max"
 CGROUP_V1_QUOTA = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
 CGROUP_V1_PERIOD = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
-
-MIN_INSTANCES = 2
-MAX_INSTANCES = 4
-
-
-def parse_quantity(value: str | None) -> float | None:
-    """Convert a Kubernetes CPU quantity ("2", "0.5", "1500m") into a number of cores."""
-    if not value:
-        return None
-    try:
-        if value.endswith("m"):
-            return float(value[:-1]) / 1000
-        return float(value)
-    except ValueError:
-        logger.warning("Unable to parse CPU quantity %r", value)
-        return None
-
-
-def container_cpu_limit(pod, container_name: str) -> float | None:
-    """Cores provisioned for a container in the pod spec, or None if it is unconstrained."""
-    spec = getattr(pod, "spec", None)
-    for container in getattr(spec, "containers", None) or []:
-        if container.name != container_name:
-            continue
-        resources = container.resources
-        if resources is None:
-            return None
-        for quantities in (resources.limits, resources.requests):
-            if quantities and (cores := parse_quantity(quantities.get("cpu"))):
-                return cores
-    return None
 
 
 def cgroup_cpu_limit(container: Container) -> float | None:

--- a/src/cpu.py
+++ b/src/cpu.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Detection of the CPU allocation provisioned for the pgbouncer container.
+
+PgBouncer is single-threaded, so the charm runs one process per provisioned CPU. The
+helpers here read a single source each; `PgBouncerK8sCharm._instance_count` is where they
+are tried in order. Note that `os.cpu_count()`, the last resort there, reports the CPUs of
+the whole node, ignoring both cgroup quotas and affinity.
+"""
+
+import logging
+
+from ops import Container
+from ops.pebble import Error as PebbleError
+
+logger = logging.getLogger(__name__)
+
+CGROUP_V2_CPU_MAX = "/sys/fs/cgroup/cpu.max"
+CGROUP_V1_QUOTA = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+CGROUP_V1_PERIOD = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+
+MIN_INSTANCES = 2
+MAX_INSTANCES = 4
+
+
+def parse_quantity(value: str | None) -> float | None:
+    """Convert a Kubernetes CPU quantity ("2", "0.5", "1500m") into a number of cores."""
+    if not value:
+        return None
+    try:
+        if value.endswith("m"):
+            return float(value[:-1]) / 1000
+        return float(value)
+    except ValueError:
+        logger.warning("Unable to parse CPU quantity %r", value)
+        return None
+
+
+def container_cpu_limit(pod, container_name: str) -> float | None:
+    """Cores provisioned for a container in the pod spec, or None if it is unconstrained."""
+    spec = getattr(pod, "spec", None)
+    for container in getattr(spec, "containers", None) or []:
+        if container.name != container_name:
+            continue
+        resources = container.resources
+        if resources is None:
+            return None
+        for quantities in (resources.limits, resources.requests):
+            if quantities and (cores := parse_quantity(quantities.get("cpu"))):
+                return cores
+    return None
+
+
+def cgroup_cpu_limit(container: Container) -> float | None:
+    """Cores enforced on the container by its cgroup, or None if it is unconstrained."""
+    if not container.can_connect():
+        return None
+
+    if cpu_max := _read_file(container, CGROUP_V2_CPU_MAX):
+        quota, _, period = cpu_max.partition(" ")
+        return _quota_to_cores(quota, period)
+
+    return _quota_to_cores(
+        _read_file(container, CGROUP_V1_QUOTA),
+        _read_file(container, CGROUP_V1_PERIOD),
+    )
+
+
+def _read_file(container: Container, path: str) -> str | None:
+    """Read a file from the container, or None if it cannot be read."""
+    try:
+        stdout, _ = container.exec(["cat", path]).wait_output()
+    except PebbleError:
+        return None
+    return stdout.strip()
+
+
+def _quota_to_cores(quota: str | None, period: str | None) -> float | None:
+    """Convert a cgroup quota/period pair into cores, or None if no quota is enforced."""
+    try:
+        cores = int(quota) / int(period)
+    except (TypeError, ValueError, ZeroDivisionError):
+        return None
+    return cores if cores > 0 else None

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -7,8 +7,6 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from cpu import MAX_INSTANCES, MIN_INSTANCES
-
 from .helpers.helpers import CHARM_SERIES, PGB, PGB_METADATA, get_cfg, run_command_on_unit
 
 logger = logging.getLogger(__name__)
@@ -26,6 +24,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm):
             resources=resources,
             application_name=PGB,
             series=CHARM_SERIES,
+            constraints={"cpu-power": 2000},
             trust=True,
         )
         await ops_test.model.wait_for_idle(apps=[PGB], status="blocked", timeout=1000)
@@ -48,14 +47,12 @@ async def test_config_updates(ops_test: OpsTest):
 async def test_multiple_pebble_services(ops_test: OpsTest):
     """Test we have the correct pebble services."""
     unit = ops_test.model.applications[PGB].units[0]
-    core_count = await run_command_on_unit(ops_test, unit.name, "nproc --all")
     get_services = await run_command_on_unit(ops_test, unit.name, "/charm/bin/pebble services")
 
     services = get_services.splitlines()[1:]
-    # No CPU limit is provisioned in this deployment, so the charm falls back to the host
-    # CPU count, clamped to the supported range. Plus the monitoring and logrotate services.
-    expected_instances = max(min(int(core_count), MAX_INSTANCES), MIN_INSTANCES)
-    assert len(services) == expected_instances + 2
+    # The app is deployed with cpu-power=2000, which Juju turns into a 2 CPU limit on the
+    # pgbouncer container, so 2 pgbouncer services run, plus monitoring and logrotate.
+    assert len(services) == 4
 
     for service in services:
         service = service.split()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -7,6 +7,8 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
+from cpu import MAX_INSTANCES, MIN_INSTANCES
+
 from .helpers.helpers import CHARM_SERIES, PGB, PGB_METADATA, get_cfg, run_command_on_unit
 
 logger = logging.getLogger(__name__)
@@ -50,8 +52,10 @@ async def test_multiple_pebble_services(ops_test: OpsTest):
     get_services = await run_command_on_unit(ops_test, unit.name, "/charm/bin/pebble services")
 
     services = get_services.splitlines()[1:]
-    # PGB services per core plus one monitoring service
-    assert len(services) == int(core_count) + 2
+    # No CPU limit is provisioned in this deployment, so the charm falls back to the host
+    # CPU count, clamped to the supported range. Plus the monitoring and logrotate services.
+    expected_instances = max(min(int(core_count), MAX_INSTANCES), MIN_INSTANCES)
+    assert len(services) == expected_instances + 2
 
     for service in services:
         service = service.split()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -24,7 +24,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm):
             resources=resources,
             application_name=PGB,
             series=CHARM_SERIES,
-            constraints={"cpu-power": 2000},
+            constraints={"cpu-power": 500},
             trust=True,
         )
         await ops_test.model.wait_for_idle(apps=[PGB], status="blocked", timeout=1000)
@@ -50,8 +50,9 @@ async def test_multiple_pebble_services(ops_test: OpsTest):
     get_services = await run_command_on_unit(ops_test, unit.name, "/charm/bin/pebble services")
 
     services = get_services.splitlines()[1:]
-    # The app is deployed with cpu-power=2000, which Juju turns into a 2 CPU limit on the
-    # pgbouncer container, so 2 pgbouncer services run, plus monitoring and logrotate.
+    # The app is deployed with cpu-power=500, which Juju turns into a 0.5 CPU limit on the
+    # pgbouncer container. That rounds up to 1 and is raised to the 2-instance minimum, so
+    # 2 pgbouncer services run, plus monitoring and logrotate.
     assert len(services) == 4
 
     for service in services:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -19,6 +19,7 @@ from ops.model import RelationDataTypeError
 from ops.testing import Harness
 from parameterized import parameterized
 
+import cpu
 from charm import PgBouncerK8sCharm
 from constants import (
     BACKEND_RELATION_NAME,
@@ -26,6 +27,22 @@ from constants import (
     PGB,
     SECRET_INTERNAL_LABEL,
 )
+from tests.unit.helpers import _FakeApiError
+
+
+def _pod_with_cpu(limit: str | None = None, request: str | None = None):
+    """Build a pod whose pgbouncer container has the given CPU limit and/or request."""
+    resources = None
+    if limit or request:
+        resources = lightkube.models.core_v1.ResourceRequirements(
+            limits={"cpu": limit} if limit else None,
+            requests={"cpu": request} if request else None,
+        )
+    return lightkube.resources.core_v1.Pod(
+        spec=lightkube.models.core_v1.PodSpec(
+            containers=[lightkube.models.core_v1.Container(name=PGB, resources=resources)]
+        )
+    )
 
 
 class TestCharm(unittest.TestCase):
@@ -950,3 +967,53 @@ class TestCharm(unittest.TestCase):
             self.harness.charm._on_secret_remove(event)
             assert not event.remove_revision.called
             event = Mock()
+
+
+class TestInstanceCount(unittest.TestCase):
+    """The number of pgbouncer processes follows the CPU provisioned by Kubernetes."""
+
+    def _services_for(self, get_pod, **exec_results):
+        harness = Harness(PgBouncerK8sCharm)
+        self.addCleanup(harness.cleanup)
+        harness.set_can_connect(PGB, True)
+        for path, result in exec_results.items():
+            harness.handle_exec(PGB, ["cat", path], result=result)
+        with patch("charm.get_pod", get_pod):
+            harness.begin()
+        return harness.charm._services
+
+    @parameterized.expand([
+        ("500m", 2),
+        ("1", 2),
+        ("2", 2),
+        ("2500m", 3),
+        ("4", 4),
+        ("16", 4),
+    ])
+    def test_rounds_the_pod_cpu_limit_up_and_clamps_it(self, quantity, expected):
+        services = self._services_for(Mock(return_value=_pod_with_cpu(limit=quantity)))
+        self.assertEqual(len(services), expected)
+
+    def test_falls_back_to_the_cpu_request_when_no_limit_is_set(self):
+        services = self._services_for(Mock(return_value=_pod_with_cpu(request="3")))
+        self.assertEqual(len(services), 3)
+
+    def test_falls_back_to_the_cgroup_quota_when_the_pod_cannot_be_read(self):
+        services = self._services_for(
+            Mock(side_effect=_FakeApiError(403)),
+            **{cpu.CGROUP_V2_CPU_MAX: "300000 100000\n"},
+        )
+        self.assertEqual(len(services), 3)
+
+    @parameterized.expand([(1, 2), (3, 3), (16, 4)])
+    def test_falls_back_to_the_host_cpu_count_when_no_limit_is_provisioned(
+        self, host_cpus, expected
+    ):
+        with patch("charm.os.cpu_count", return_value=host_cpus):
+            services = self._services_for(Mock(return_value=_pod_with_cpu()))
+        self.assertEqual(len(services), expected)
+
+    def test_falls_back_to_the_minimum_when_the_host_cpu_count_is_unavailable(self):
+        with patch("charm.os.cpu_count", return_value=None):
+            services = self._services_for(Mock(return_value=_pod_with_cpu()))
+        self.assertEqual(len(services), cpu.MIN_INSTANCES)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,7 +16,7 @@ import pytest
 from jinja2 import Template
 from ops import BlockedStatus, JujuVersion
 from ops.model import RelationDataTypeError
-from ops.testing import Harness
+from ops.testing import ExecResult, Harness
 from parameterized import parameterized
 
 import cpu
@@ -27,22 +27,6 @@ from constants import (
     PGB,
     SECRET_INTERNAL_LABEL,
 )
-from tests.unit.helpers import _FakeApiError
-
-
-def _pod_with_cpu(limit: str | None = None, request: str | None = None):
-    """Build a pod whose pgbouncer container has the given CPU limit and/or request."""
-    resources = None
-    if limit or request:
-        resources = lightkube.models.core_v1.ResourceRequirements(
-            limits={"cpu": limit} if limit else None,
-            requests={"cpu": request} if request else None,
-        )
-    return lightkube.resources.core_v1.Pod(
-        spec=lightkube.models.core_v1.PodSpec(
-            containers=[lightkube.models.core_v1.Container(name=PGB, resources=resources)]
-        )
-    )
 
 
 class TestCharm(unittest.TestCase):
@@ -972,48 +956,38 @@ class TestCharm(unittest.TestCase):
 class TestInstanceCount(unittest.TestCase):
     """The number of pgbouncer processes follows the CPU provisioned by Kubernetes."""
 
-    def _services_for(self, get_pod, **exec_results):
+    def _services_for(self, cpu_max=None):
         harness = Harness(PgBouncerK8sCharm)
         self.addCleanup(harness.cleanup)
         harness.set_can_connect(PGB, True)
-        for path, result in exec_results.items():
-            harness.handle_exec(PGB, ["cat", path], result=result)
-        with patch("charm.get_pod", get_pod):
-            harness.begin()
+        harness.handle_exec(PGB, ["cat"], result=ExecResult(exit_code=1, stderr="No such file"))
+        if cpu_max is not None:
+            harness.handle_exec(PGB, ["cat", cpu.CGROUP_V2_CPU_MAX], result=cpu_max)
+        harness.begin()
         return harness.charm._services
 
     @parameterized.expand([
-        ("500m", 2),
-        ("1", 2),
-        ("2", 2),
-        ("2500m", 3),
-        ("4", 4),
-        ("16", 4),
+        ("50000 100000", 2),
+        ("100000 100000", 2),
+        ("200000 100000", 2),
+        ("250000 100000", 3),
+        ("400000 100000", 4),
+        ("1600000 100000", 4),
     ])
-    def test_rounds_the_pod_cpu_limit_up_and_clamps_it(self, quantity, expected):
-        services = self._services_for(Mock(return_value=_pod_with_cpu(limit=quantity)))
-        self.assertEqual(len(services), expected)
-
-    def test_falls_back_to_the_cpu_request_when_no_limit_is_set(self):
-        services = self._services_for(Mock(return_value=_pod_with_cpu(request="3")))
-        self.assertEqual(len(services), 3)
-
-    def test_falls_back_to_the_cgroup_quota_when_the_pod_cannot_be_read(self):
-        services = self._services_for(
-            Mock(side_effect=_FakeApiError(403)),
-            **{cpu.CGROUP_V2_CPU_MAX: "300000 100000\n"},
-        )
-        self.assertEqual(len(services), 3)
+    def test_rounds_the_cgroup_quota_up_and_clamps_it(self, cpu_max, expected):
+        self.assertEqual(len(self._services_for(cpu_max)), expected)
 
     @parameterized.expand([(1, 2), (3, 3), (16, 4)])
-    def test_falls_back_to_the_host_cpu_count_when_no_limit_is_provisioned(
-        self, host_cpus, expected
-    ):
+    def test_falls_back_to_the_host_cpu_count_when_no_quota_is_enforced(self, host_cpus, expected):
         with patch("charm.os.cpu_count", return_value=host_cpus):
-            services = self._services_for(Mock(return_value=_pod_with_cpu()))
-        self.assertEqual(len(services), expected)
+            self.assertEqual(len(self._services_for("max 100000")), expected)
 
-    def test_falls_back_to_the_minimum_when_the_host_cpu_count_is_unavailable(self):
-        with patch("charm.os.cpu_count", return_value=None):
-            services = self._services_for(Mock(return_value=_pod_with_cpu()))
-        self.assertEqual(len(services), cpu.MIN_INSTANCES)
+    def test_falls_back_to_the_host_cpu_count_when_the_cgroup_is_unreadable(self):
+        with patch("charm.os.cpu_count", return_value=3):
+            self.assertEqual(len(self._services_for()), 3)
+
+    def test_does_not_read_the_kubernetes_api(self):
+        """Reading the pod spec here would put a blocking API call in every hook."""
+        with patch("charm.get_pod") as get_pod:
+            self._services_for("200000 100000")
+        get_pod.assert_not_called()

--- a/tests/unit/test_cpu.py
+++ b/tests/unit/test_cpu.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+
+from lightkube.models.core_v1 import Container, PodSpec, ResourceRequirements
+from lightkube.resources.core_v1 import Pod
+from ops.testing import ExecResult, Harness
+from parameterized import parameterized
+
+import cpu
+from charm import PgBouncerK8sCharm
+from constants import PGB
+
+
+def _pod(resources: ResourceRequirements | None, name: str = PGB) -> Pod:
+    return Pod(spec=PodSpec(containers=[Container(name=name, resources=resources)]))
+
+
+class TestParseQuantity(unittest.TestCase):
+    @parameterized.expand([
+        ("2", 2.0),
+        ("1", 1.0),
+        ("0.5", 0.5),
+        ("1500m", 1.5),
+        ("500m", 0.5),
+        ("100m", 0.1),
+    ])
+    def test_parses_kubernetes_cpu_quantities(self, value, expected):
+        self.assertAlmostEqual(cpu.parse_quantity(value), expected)
+
+    @parameterized.expand([("",), ("abc",), ("m",), ("1.5.2",), ("max",)])
+    def test_returns_none_for_unparseable_values(self, value):
+        self.assertIsNone(cpu.parse_quantity(value))
+
+
+class TestContainerCpuLimit(unittest.TestCase):
+    def test_prefers_the_cpu_limit(self):
+        pod = _pod(ResourceRequirements(limits={"cpu": "2"}, requests={"cpu": "1"}))
+        self.assertEqual(cpu.container_cpu_limit(pod, PGB), 2.0)
+
+    def test_falls_back_to_the_cpu_request_when_no_limit_is_set(self):
+        pod = _pod(ResourceRequirements(requests={"cpu": "1500m"}))
+        self.assertEqual(cpu.container_cpu_limit(pod, PGB), 1.5)
+
+    def test_falls_back_to_the_cpu_request_when_limits_omit_cpu(self):
+        pod = _pod(ResourceRequirements(limits={"memory": "1Gi"}, requests={"cpu": "2"}))
+        self.assertEqual(cpu.container_cpu_limit(pod, PGB), 2.0)
+
+    def test_returns_none_when_the_container_has_no_resources(self):
+        self.assertIsNone(cpu.container_cpu_limit(_pod(None), PGB))
+
+    def test_returns_none_when_neither_limit_nor_request_sets_cpu(self):
+        pod = _pod(ResourceRequirements(limits={"memory": "1Gi"}))
+        self.assertIsNone(cpu.container_cpu_limit(pod, PGB))
+
+    def test_ignores_other_containers_in_the_pod(self):
+        pod = _pod(ResourceRequirements(limits={"cpu": "8"}), name="charm")
+        self.assertIsNone(cpu.container_cpu_limit(pod, PGB))
+
+    def test_returns_none_when_the_pod_has_no_spec(self):
+        self.assertIsNone(cpu.container_cpu_limit(Pod(), PGB))
+
+
+class TestCgroupCpuLimit(unittest.TestCase):
+    def setUp(self):
+        self.harness = Harness(PgBouncerK8sCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+        self.container = self.harness.charm.unit.get_container(PGB)
+
+    def _handle(self, path, result):
+        self.harness.handle_exec(PGB, ["cat", path], result=result)
+
+    def test_reads_the_quota_from_cgroup_v2(self):
+        self.harness.set_can_connect(PGB, True)
+        self._handle(cpu.CGROUP_V2_CPU_MAX, "200000 100000\n")
+        self.assertEqual(cpu.cgroup_cpu_limit(self.container), 2.0)
+
+    def test_returns_none_when_cgroup_v2_reports_no_quota(self):
+        self.harness.set_can_connect(PGB, True)
+        self._handle(cpu.CGROUP_V2_CPU_MAX, "max 100000\n")
+        self.assertIsNone(cpu.cgroup_cpu_limit(self.container))
+
+    def test_falls_back_to_cgroup_v1_when_v2_is_absent(self):
+        self.harness.set_can_connect(PGB, True)
+        self._handle(cpu.CGROUP_V2_CPU_MAX, ExecResult(exit_code=1, stderr="No such file"))
+        self._handle(cpu.CGROUP_V1_QUOTA, "150000\n")
+        self._handle(cpu.CGROUP_V1_PERIOD, "100000\n")
+        self.assertEqual(cpu.cgroup_cpu_limit(self.container), 1.5)
+
+    def test_returns_none_when_cgroup_v1_quota_is_unset(self):
+        self.harness.set_can_connect(PGB, True)
+        self._handle(cpu.CGROUP_V2_CPU_MAX, ExecResult(exit_code=1, stderr="No such file"))
+        self._handle(cpu.CGROUP_V1_QUOTA, "-1\n")
+        self._handle(cpu.CGROUP_V1_PERIOD, "100000\n")
+        self.assertIsNone(cpu.cgroup_cpu_limit(self.container))
+
+    def test_returns_none_when_no_cgroup_file_can_be_read(self):
+        self.harness.set_can_connect(PGB, True)
+        self.harness.handle_exec(PGB, ["cat"], result=ExecResult(exit_code=1, stderr="nope"))
+        self.assertIsNone(cpu.cgroup_cpu_limit(self.container))
+
+    def test_returns_none_when_the_container_is_unreachable(self):
+        self.harness.set_can_connect(PGB, False)
+        self.assertIsNone(cpu.cgroup_cpu_limit(self.container))

--- a/tests/unit/test_cpu.py
+++ b/tests/unit/test_cpu.py
@@ -3,63 +3,11 @@
 
 import unittest
 
-from lightkube.models.core_v1 import Container, PodSpec, ResourceRequirements
-from lightkube.resources.core_v1 import Pod
 from ops.testing import ExecResult, Harness
-from parameterized import parameterized
 
 import cpu
 from charm import PgBouncerK8sCharm
 from constants import PGB
-
-
-def _pod(resources: ResourceRequirements | None, name: str = PGB) -> Pod:
-    return Pod(spec=PodSpec(containers=[Container(name=name, resources=resources)]))
-
-
-class TestParseQuantity(unittest.TestCase):
-    @parameterized.expand([
-        ("2", 2.0),
-        ("1", 1.0),
-        ("0.5", 0.5),
-        ("1500m", 1.5),
-        ("500m", 0.5),
-        ("100m", 0.1),
-    ])
-    def test_parses_kubernetes_cpu_quantities(self, value, expected):
-        self.assertAlmostEqual(cpu.parse_quantity(value), expected)
-
-    @parameterized.expand([("",), ("abc",), ("m",), ("1.5.2",), ("max",)])
-    def test_returns_none_for_unparseable_values(self, value):
-        self.assertIsNone(cpu.parse_quantity(value))
-
-
-class TestContainerCpuLimit(unittest.TestCase):
-    def test_prefers_the_cpu_limit(self):
-        pod = _pod(ResourceRequirements(limits={"cpu": "2"}, requests={"cpu": "1"}))
-        self.assertEqual(cpu.container_cpu_limit(pod, PGB), 2.0)
-
-    def test_falls_back_to_the_cpu_request_when_no_limit_is_set(self):
-        pod = _pod(ResourceRequirements(requests={"cpu": "1500m"}))
-        self.assertEqual(cpu.container_cpu_limit(pod, PGB), 1.5)
-
-    def test_falls_back_to_the_cpu_request_when_limits_omit_cpu(self):
-        pod = _pod(ResourceRequirements(limits={"memory": "1Gi"}, requests={"cpu": "2"}))
-        self.assertEqual(cpu.container_cpu_limit(pod, PGB), 2.0)
-
-    def test_returns_none_when_the_container_has_no_resources(self):
-        self.assertIsNone(cpu.container_cpu_limit(_pod(None), PGB))
-
-    def test_returns_none_when_neither_limit_nor_request_sets_cpu(self):
-        pod = _pod(ResourceRequirements(limits={"memory": "1Gi"}))
-        self.assertIsNone(cpu.container_cpu_limit(pod, PGB))
-
-    def test_ignores_other_containers_in_the_pod(self):
-        pod = _pod(ResourceRequirements(limits={"cpu": "8"}), name="charm")
-        self.assertIsNone(cpu.container_cpu_limit(pod, PGB))
-
-    def test_returns_none_when_the_pod_has_no_spec(self):
-        self.assertIsNone(cpu.container_cpu_limit(Pod(), PGB))
 
 
 class TestCgroupCpuLimit(unittest.TestCase):


### PR DESCRIPTION
Fixes #834.

The instance count came from `os.cpu_count()`, which reports the whole node and ignores
the pod's cgroup quota. A unit deployed with `--constraints "cpu-power=2000"` (`cores=2`)
ran 4 instances instead of 2.

`_instance_count()` now reads the `pgbouncer` container's CPU limit (or request) from the
pod spec, falling back to the container's cgroup quota, then to the host CPU count. Still
rounded up and clamped to 2–4, so unconstrained deployments are unchanged.

#834 also proposes a `juju config instances=N` option; this PR makes the count follow the
constraints already set instead, so the issue should stay open for that request.

**Testing:** 42 unit tests covering each source and fallback. The integration test
compared against raw `nproc --all`, which only held on 2–4 core runners; it now applies
the same clamp.

**Before merge:** confirm Juju puts a `cores` constraint on the `pgbouncer` container and
not just the `charm` container — if the latter, detection falls through to the host CPU
count and #834's repro is unchanged.